### PR TITLE
[Feat-T3-57] NetworkService 구현

### DIFF
--- a/Bitnagil.xcworkspace/xcshareddata/xcschemes/Bitnagil-Workspace.xcscheme
+++ b/Bitnagil.xcworkspace/xcshareddata/xcschemes/Bitnagil-Workspace.xcscheme
@@ -42,6 +42,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AED19AA06D0E2E3A22B4D9A0"
+               BuildableName = "DataSource_DataSource.bundle"
+               BlueprintName = "DataSource_DataSource"
+               ReferencedContainer = "container:Projects/DataSource/DataSource.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "C538ACB2975E6B55AFA02B19"
                BuildableName = "Domain.framework"
                BlueprintName = "Domain"

--- a/Projects/App/App.xcodeproj/project.pbxproj
+++ b/Projects/App/App.xcodeproj/project.pbxproj
@@ -10,13 +10,17 @@
 		004FD1E183A2F52A4913C9DB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7210F22777D23AD1713BCADE /* AppDelegate.swift */; };
 		0F3EBD548A92D7401B1FC633 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 057A3CD8D734F9C1B4948C18 /* LaunchScreen.storyboard */; };
 		13E38F429DD38A875929954E /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AB40F3B3D8E2DCB2AC3C9605 /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		15B02FAF01FD1AD77840A002 /* Persistence.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A8A366CA149895A8FD2C324 /* Persistence.framework */; };
 		1BC5B98AD386E5E8F84A45D6 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB40F3B3D8E2DCB2AC3C9605 /* Shared.framework */; };
 		1CC5497D4325800197E0D4AD /* Presentation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 537ED5DBF00B5D2B5A03A60B /* Presentation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2E743A6F76CCB6064D781210 /* TuistAssets+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D529DAAF6A9D59C44D9D68 /* TuistAssets+App.swift */; };
 		467D7D6A8B87418133528331 /* SnapKit_SnapKit.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 4C594D8BDE1AF55813EE2F2C /* SnapKit_SnapKit.bundle */; };
 		4787DFDD71F731243F3587AF /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BEB75E9463ACE494A73BD36 /* Domain.framework */; };
 		48469C5111BF762561C9B9B6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8F7F83A194E1D17030DCA033 /* Assets.xcassets */; };
+		55E452A4720AF4E805648B50 /* DataSource_DataSource.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 49A913A25DE16C311227243F /* DataSource_DataSource.bundle */; };
 		791E438F57DB6775DD4A8170 /* Domain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6BEB75E9463ACE494A73BD36 /* Domain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7BB34C4538C942D09D64DBF0 /* NetworkService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 792CA40B8758B40F19BCB0F0 /* NetworkService.framework */; };
+		88527F8D04C87E1DDD28C480 /* DataSource_DataSource.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 49A913A25DE16C311227243F /* DataSource_DataSource.bundle */; };
 		9E6569B360C5040FD4C8A7FA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED69542D699D2104EE8BFC4 /* SceneDelegate.swift */; };
 		D2A6696095E956AD7CB66182 /* SnapKit_SnapKit.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4C594D8BDE1AF55813EE2F2C /* SnapKit_SnapKit.bundle */; };
 		E678B6575F4098186CCAA823 /* DataSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42FBCA54F0C56C37162AF664 /* DataSource.framework */; };
@@ -43,6 +47,7 @@
 			buildActionMask = 8;
 			dstSubfolderSpec = 16;
 			files = (
+				88527F8D04C87E1DDD28C480 /* DataSource_DataSource.bundle in Dependencies */,
 				467D7D6A8B87418133528331 /* SnapKit_SnapKit.bundle in Dependencies */,
 			);
 			name = Dependencies;
@@ -55,13 +60,16 @@
 		083CD4D343ECF7F321C1905D /* TuistBundle+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+App.swift"; sourceTree = "<group>"; };
 		1ED69542D699D2104EE8BFC4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		42FBCA54F0C56C37162AF664 /* DataSource.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DataSource.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		49A913A25DE16C311227243F /* DataSource_DataSource.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DataSource_DataSource.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C594D8BDE1AF55813EE2F2C /* SnapKit_SnapKit.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SnapKit_SnapKit.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		537ED5DBF00B5D2B5A03A60B /* Presentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Presentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		571E08A9083FD4334E4B7D06 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BEB75E9463ACE494A73BD36 /* Domain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Domain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7210F22777D23AD1713BCADE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		792CA40B8758B40F19BCB0F0 /* NetworkService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NetworkService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F7F83A194E1D17030DCA033 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		95D529DAAF6A9D59C44D9D68 /* TuistAssets+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+App.swift"; sourceTree = "<group>"; };
+		9A8A366CA149895A8FD2C324 /* Persistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Persistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB40F3B3D8E2DCB2AC3C9605 /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F13E636A9305A42EC91FE66D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -73,6 +81,8 @@
 			files = (
 				E678B6575F4098186CCAA823 /* DataSource.framework in Frameworks */,
 				4787DFDD71F731243F3587AF /* Domain.framework in Frameworks */,
+				7BB34C4538C942D09D64DBF0 /* NetworkService.framework in Frameworks */,
+				15B02FAF01FD1AD77840A002 /* Persistence.framework in Frameworks */,
 				F8791705E402BF780055F988 /* Presentation.framework in Frameworks */,
 				1BC5B98AD386E5E8F84A45D6 /* Shared.framework in Frameworks */,
 			);
@@ -139,8 +149,11 @@
 			isa = PBXGroup;
 			children = (
 				571E08A9083FD4334E4B7D06 /* App.app */,
+				49A913A25DE16C311227243F /* DataSource_DataSource.bundle */,
 				42FBCA54F0C56C37162AF664 /* DataSource.framework */,
 				6BEB75E9463ACE494A73BD36 /* Domain.framework */,
+				792CA40B8758B40F19BCB0F0 /* NetworkService.framework */,
+				9A8A366CA149895A8FD2C324 /* Persistence.framework */,
 				537ED5DBF00B5D2B5A03A60B /* Presentation.framework */,
 				AB40F3B3D8E2DCB2AC3C9605 /* Shared.framework */,
 				4C594D8BDE1AF55813EE2F2C /* SnapKit_SnapKit.bundle */,
@@ -205,6 +218,7 @@
 			files = (
 				48469C5111BF762561C9B9B6 /* Assets.xcassets in Resources */,
 				0F3EBD548A92D7401B1FC633 /* LaunchScreen.storyboard in Resources */,
+				55E452A4720AF4E805648B50 /* DataSource_DataSource.bundle in Resources */,
 				D2A6696095E956AD7CB66182 /* SnapKit_SnapKit.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -25,6 +25,8 @@ let project = Project(
                 .project(target: "Presentation", path: "../Presentation"),
                 .project(target: "Domain", path: "../Domain"),
                 .project(target: "DataSource", path: "../DataSource"),
+                .project(target: "NetworkService", path: "../NetworkService"),
+                .project(target: "Persistence", path: "../Persistence"),
                 .project(target: "Shared", path: "../Shared")
             ]
         )

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -6,16 +6,34 @@
 //
 
 import UIKit
+import DataSource
+import Domain
 import Presentation
+import NetworkService
+import Shared
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
+    // TODO: DI 수정 필요
+    private func dependencyInjection() {
+        let networkService = NetworkService()
+        DIContainer.shared.register(type: NetworkServiceProtocol.self, instance: networkService)
+
+        let testRepository: TestRepositoryProtocol = TestRepository(networkService: networkService)
+        DIContainer.shared.register(type: TestRepositoryProtocol.self, instance: testRepository)
+
+        let testUseCase: TestUseCase = TestUseCase(testRepository: testRepository)
+        DIContainer.shared.register(type: TestUseCase.self, instance: testUseCase)
+    }
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
+        dependencyInjection()
 
-        let navigationController = UINavigationController(rootViewController: HomeViewController())
+        let testUseCase = DIContainer.shared.resolve(type: TestUseCase.self)!
+        let navigationController = UINavigationController(rootViewController: HomeViewController(usecase: testUseCase))
         navigationController.isNavigationBarHidden = true
         window.rootViewController = navigationController
         window.makeKeyAndVisible()

--- a/Projects/DataSource/DataSource.xcodeproj/project.pbxproj
+++ b/Projects/DataSource/DataSource.xcodeproj/project.pbxproj
@@ -8,11 +8,40 @@
 
 /* Begin PBXBuildFile section */
 		04248AC07EF7C561629220D4 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CBCB96722F90914CB2EC15B /* Shared.framework */; };
+		24EB34C9612C67F807B36FC0 /* BaseResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE682F2D257198BA363E0CBB /* BaseResponseDTO.swift */; };
+		40B3EAFCE7E70C99028540D7 /* NetworkServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978C408D448C4210F6E4BAF8 /* NetworkServiceProtocol.swift */; };
+		4553354DFBF0312EB968B11F /* TestRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F790F52CC0D64AF84B73C5 /* TestRepository.swift */; };
+		51DBACDB7A9D8D46AF08CFB1 /* TuistBundle+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFAE956BE2D9926E9A22ADF /* TuistBundle+DataSource.swift */; };
+		5DF33D73E0EDC22E663F8BA3 /* TestEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A843EA0A49DC1D294D5F41B /* TestEndpoint.swift */; };
+		7E12CC7308B3EB0757A63130 /* HealthCheckRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEACD5EC6C35913BBCFC3E5 /* HealthCheckRequestDTO.swift */; };
 		95EB7046E1E61A9470A99CDA /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 057C674D3AD26CB7C4C508C1 /* Domain.framework */; };
-		B96817B0BF039487DF13859B /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA507960687D9F460252EF99 /* DataSource.swift */; };
+		9FA1BBDEDD5F6848C156B8BC /* AppProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A1674CACD751CD6CF69204 /* AppProperties.swift */; };
+		C903BF45DEA71058E8D80871 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1231C6C62297625690767854 /* Secrets.xcconfig */; };
+		F88DDF2AD24570A292FBFAEF /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AD44CFA8C16BD75C144C6A /* HTTPMethod.swift */; };
+		FADBD0532CB73D22B14A2A2A /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918BD42A72B6547A72A1D04C /* Endpoint.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		1278AD216BC551EAF8BDADE6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7CA1BFF1FCF6527CAEBE455F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AED19AA06D0E2E3A22B4D9A0;
+			remoteInfo = DataSource_DataSource;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
+		B8DCDA9008821D6C783F0EB4 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CE65733DC9674134773AD92C /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -27,13 +56,31 @@
 
 /* Begin PBXFileReference section */
 		057C674D3AD26CB7C4C508C1 /* Domain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Domain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1231C6C62297625690767854 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		17AFB03555DD7AF9224C2383 /* DataSource_DataSource-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DataSource_DataSource-Info.plist"; sourceTree = "<group>"; };
+		19AD44CFA8C16BD75C144C6A /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		24A1674CACD751CD6CF69204 /* AppProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppProperties.swift; sourceTree = "<group>"; };
+		2DEACD5EC6C35913BBCFC3E5 /* HealthCheckRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCheckRequestDTO.swift; sourceTree = "<group>"; };
 		3CBCB96722F90914CB2EC15B /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6069F156A6F8EC50E8646060 /* DataSource.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DataSource.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DA507960687D9F460252EF99 /* DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
-		DA5AEFFAFE6E9DC454C61BB2 /* DataSource-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DataSource-Info.plist"; sourceTree = "<group>"; };
+		6FFAE956BE2D9926E9A22ADF /* TuistBundle+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+DataSource.swift"; sourceTree = "<group>"; };
+		76F790F52CC0D64AF84B73C5 /* TestRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRepository.swift; sourceTree = "<group>"; };
+		8A843EA0A49DC1D294D5F41B /* TestEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEndpoint.swift; sourceTree = "<group>"; };
+		918BD42A72B6547A72A1D04C /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		978C408D448C4210F6E4BAF8 /* NetworkServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceProtocol.swift; sourceTree = "<group>"; };
+		AE682F2D257198BA363E0CBB /* BaseResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponseDTO.swift; sourceTree = "<group>"; };
+		DA4E03394E3F3CF0C66993C6 /* DataSource_DataSource.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DataSource_DataSource.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		F6D101F50EC5C77ABE6EA7FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		149CBEEA602BD6ECD805D5DD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C1E8A3EACD51178306C59A47 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -50,14 +97,42 @@
 			isa = PBXGroup;
 			children = (
 				85859BA397D1C615A9242584 /* Derived */,
+				D1987B71B67AE5ACDECCEF7B /* Resources */,
 				F3DFA10A9D80DE0FEBD2D32E /* Sources */,
 			);
 			name = Project;
 			sourceTree = "<group>";
 		};
+		2FED8A84F500D508FBEDE55D /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				24A1674CACD751CD6CF69204 /* AppProperties.swift */,
+				918BD42A72B6547A72A1D04C /* Endpoint.swift */,
+				19AD44CFA8C16BD75C144C6A /* HTTPMethod.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		3B3D90519B713912DA21AB8C /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				76F790F52CC0D64AF84B73C5 /* TestRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		59A7A28D6ED4CD892AEC4DFE /* Endpoints */ = {
+			isa = PBXGroup;
+			children = (
+				8A843EA0A49DC1D294D5F41B /* TestEndpoint.swift */,
+			);
+			path = Endpoints;
+			sourceTree = "<group>";
+		};
 		5DCE4BC6D6FE2C61EBEBBB57 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				DA4E03394E3F3CF0C66993C6 /* DataSource_DataSource.bundle */,
 				6069F156A6F8EC50E8646060 /* DataSource.framework */,
 				057C674D3AD26CB7C4C508C1 /* Domain.framework */,
 				3CBCB96722F90914CB2EC15B /* Shared.framework */,
@@ -65,12 +140,38 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		7197A43B0DB19D609772738B /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				AE682F2D257198BA363E0CBB /* BaseResponseDTO.swift */,
+				2DEACD5EC6C35913BBCFC3E5 /* HealthCheckRequestDTO.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		7A93B9FE3989B7A2AFC031CF /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				6FFAE956BE2D9926E9A22ADF /* TuistBundle+DataSource.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		85859BA397D1C615A9242584 /* Derived */ = {
 			isa = PBXGroup;
 			children = (
 				F266C34310AA5677AB606218 /* InfoPlists */,
+				7A93B9FE3989B7A2AFC031CF /* Sources */,
 			);
 			path = Derived;
+			sourceTree = "<group>";
+		};
+		99D8F7825878B0B285A3B198 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				978C408D448C4210F6E4BAF8 /* NetworkServiceProtocol.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		A9B255848FC7C50F5AE4D99B = {
@@ -81,10 +182,19 @@
 			);
 			sourceTree = "<group>";
 		};
+		D1987B71B67AE5ACDECCEF7B /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				F6D101F50EC5C77ABE6EA7FC /* Info.plist */,
+				1231C6C62297625690767854 /* Secrets.xcconfig */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		F266C34310AA5677AB606218 /* InfoPlists */ = {
 			isa = PBXGroup;
 			children = (
-				DA5AEFFAFE6E9DC454C61BB2 /* DataSource-Info.plist */,
+				17AFB03555DD7AF9224C2383 /* DataSource_DataSource-Info.plist */,
 			);
 			path = InfoPlists;
 			sourceTree = "<group>";
@@ -92,7 +202,11 @@
 		F3DFA10A9D80DE0FEBD2D32E /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				DA507960687D9F460252EF99 /* DataSource.swift */,
+				7197A43B0DB19D609772738B /* DTO */,
+				59A7A28D6ED4CD892AEC4DFE /* Endpoints */,
+				2FED8A84F500D508FBEDE55D /* Network */,
+				99D8F7825878B0B285A3B198 /* Protocols */,
+				3B3D90519B713912DA21AB8C /* Repositories */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -112,6 +226,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				BFFE54E8A9796CF9018898D6 /* PBXTargetDependency */,
 			);
 			name = DataSource;
 			packageProductDependencies = (
@@ -119,6 +234,25 @@
 			productName = DataSource;
 			productReference = 6069F156A6F8EC50E8646060 /* DataSource.framework */;
 			productType = "com.apple.product-type.framework";
+		};
+		AED19AA06D0E2E3A22B4D9A0 /* DataSource_DataSource */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3FFAC572D035985484CD170B /* Build configuration list for PBXNativeTarget "DataSource_DataSource" */;
+			buildPhases = (
+				AFE7B22874B2E444A4DEA3CF /* Resources */,
+				149CBEEA602BD6ECD805D5DD /* Frameworks */,
+				B8DCDA9008821D6C783F0EB4 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DataSource_DataSource;
+			packageProductDependencies = (
+			);
+			productName = DataSource_DataSource;
+			productReference = DA4E03394E3F3CF0C66993C6 /* DataSource_DataSource.bundle */;
+			productType = "com.apple.product-type.bundle";
 		};
 /* End PBXNativeTarget section */
 
@@ -142,6 +276,7 @@
 			projectRoot = "";
 			targets = (
 				3A2533EC4A41F2C670C52385 /* DataSource */,
+				AED19AA06D0E2E3A22B4D9A0 /* DataSource_DataSource */,
 			);
 		};
 /* End PBXProject section */
@@ -154,6 +289,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AFE7B22874B2E444A4DEA3CF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C903BF45DEA71058E8D80871 /* Secrets.xcconfig in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -161,13 +304,52 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B96817B0BF039487DF13859B /* DataSource.swift in Sources */,
+				51DBACDB7A9D8D46AF08CFB1 /* TuistBundle+DataSource.swift in Sources */,
+				24EB34C9612C67F807B36FC0 /* BaseResponseDTO.swift in Sources */,
+				7E12CC7308B3EB0757A63130 /* HealthCheckRequestDTO.swift in Sources */,
+				5DF33D73E0EDC22E663F8BA3 /* TestEndpoint.swift in Sources */,
+				9FA1BBDEDD5F6848C156B8BC /* AppProperties.swift in Sources */,
+				FADBD0532CB73D22B14A2A2A /* Endpoint.swift in Sources */,
+				F88DDF2AD24570A292FBFAEF /* HTTPMethod.swift in Sources */,
+				40B3EAFCE7E70C99028540D7 /* NetworkServiceProtocol.swift in Sources */,
+				4553354DFBF0312EB968B11F /* TestRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		BFFE54E8A9796CF9018898D6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = DataSource_DataSource;
+			target = AED19AA06D0E2E3A22B4D9A0 /* DataSource_DataSource */;
+			targetProxy = 1278AD216BC551EAF8BDADE6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		28A4D66DBE575E44B7AD7D94 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_MASTER_OBJECT_FILE = NO;
+				INFOPLIST_FILE = "Derived/InfoPlists/DataSource_DataSource-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitnagil.datasource.resources;
+				PRODUCT_NAME = DataSource_DataSource;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		2E5D4E391988F93F2FBEF879 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -177,7 +359,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DataSource-Info.plist";
+				INFOPLIST_FILE = Resources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -204,6 +386,7 @@
 		};
 		51C0D9FFA9CC6F2A84AB2437 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1231C6C62297625690767854 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -264,7 +447,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DataSource-Info.plist";
+				INFOPLIST_FILE = Resources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -293,8 +476,35 @@
 			};
 			name = Debug;
 		};
+		875D7426D78B25690807C394 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_MASTER_OBJECT_FILE = NO;
+				INFOPLIST_FILE = "Derived/InfoPlists/DataSource_DataSource-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitnagil.datasource.resources;
+				PRODUCT_NAME = DataSource_DataSource;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+					"$(inherited)",
+					DEBUG,
+				);
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 		F798A10F1FD8F98E7653EF44 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1231C6C62297625690767854 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -360,6 +570,15 @@
 			buildConfigurations = (
 				55C934C9A87A02E6D391AC89 /* Debug */,
 				2E5D4E391988F93F2FBEF879 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3FFAC572D035985484CD170B /* Build configuration list for PBXNativeTarget "DataSource_DataSource" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				875D7426D78B25690807C394 /* Debug */,
+				28A4D66DBE575E44B7AD7D94 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Projects/DataSource/DataSource.xcodeproj/xcshareddata/xcschemes/DataSource_DataSource.xcscheme
+++ b/Projects/DataSource/DataSource.xcodeproj/xcshareddata/xcschemes/DataSource_DataSource.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AED19AA06D0E2E3A22B4D9A0"
+               BuildableName = "DataSource_DataSource.bundle"
+               BlueprintName = "DataSource_DataSource"
+               ReferencedContainer = "container:DataSource.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      disableMainThreadChecker = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AED19AA06D0E2E3A22B4D9A0"
+            BuildableName = "DataSource_DataSource.bundle"
+            BlueprintName = "DataSource_DataSource"
+            ReferencedContainer = "container:DataSource.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AED19AA06D0E2E3A22B4D9A0"
+            BuildableName = "DataSource_DataSource.bundle"
+            BlueprintName = "DataSource_DataSource"
+            ReferencedContainer = "container:DataSource.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Projects/DataSource/Derived/InfoPlists/DataSource_DataSource-Info.plist
+++ b/Projects/DataSource/Derived/InfoPlists/DataSource_DataSource-Info.plist
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BaseURL</key>
+	<string>$(BASE_URL)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
+	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/Projects/DataSource/Derived/Sources/TuistBundle+DataSource.swift
+++ b/Projects/DataSource/Derived/Sources/TuistBundle+DataSource.swift
@@ -1,0 +1,59 @@
+// swiftlint:disable:this file_name
+// swiftlint:disable all
+// swift-format-ignore-file
+// swiftformat:disable all
+import Foundation
+// MARK: - Swift Bundle Accessor - for SPM
+private class BundleFinder {}
+extension Foundation.Bundle {
+/// Since DataSource is a static framework, the bundle containing the resources is copied into the final product.
+static let module: Bundle = {
+    let bundleName = "DataSource_DataSource"
+    let bundleFinderResourceURL = Bundle(for: BundleFinder.self).resourceURL
+    var candidates = [
+        Bundle.main.resourceURL,
+        bundleFinderResourceURL,
+        Bundle.main.bundleURL,
+    ]
+    // This is a fix to make Previews work with bundled resources.
+    // Logic here is taken from SPM's generated `resource_bundle_accessors.swift` file,
+    // which is located under the derived data directory after building the project.
+    if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
+        candidates.append(URL(fileURLWithPath: override))
+        // Deleting derived data and not rebuilding the frameworks containing resources may result in a state
+        // where the bundles are only available in the framework's directory that is actively being previewed.
+        // Since we don't know which framework this is, we also need to look in all the framework subpaths.
+        if let subpaths = try? FileManager.default.contentsOfDirectory(atPath: override) {
+            for subpath in subpaths {
+                if subpath.hasSuffix(".framework") {
+                    candidates.append(URL(fileURLWithPath: override + "/" + subpath))
+                }
+            }
+        }
+    }
+
+    // This is a fix to make unit tests work with bundled resources.
+    // Making this change allows unit tests to search one directory up for a bundle.
+    // More context can be found in this PR: https://github.com/tuist/tuist/pull/6895
+    #if canImport(XCTest)
+    candidates.append(bundleFinderResourceURL?.appendingPathComponent(".."))
+    #endif
+
+    for candidate in candidates {
+        let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+        if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+            return bundle
+        }
+    }
+    fatalError("unable to find bundle named DataSource_DataSource")
+}()
+}
+// MARK: - Objective-C Bundle Accessor
+@objc
+public class DataSourceResources: NSObject {
+@objc public class var bundle: Bundle {
+    return .module
+}
+}
+// swiftformat:enable all
+// swiftlint:enable all

--- a/Projects/DataSource/Project.swift
+++ b/Projects/DataSource/Project.swift
@@ -2,6 +2,14 @@ import ProjectDescription
 
 let project = Project(
     name: "DataSource",
+    settings: .settings(
+        base: [:],
+        configurations: [
+            .debug(name: "Debug", xcconfig: .relativeToRoot("Projects/DataSource/Resources/Secrets.xcconfig")),
+            .release(name: "Release", xcconfig: .relativeToRoot("Projects/DataSource/Resources/Secrets.xcconfig"))
+        ],
+        defaultSettings: .recommended
+    ),
     targets: [
         .target(
             name: "DataSource",
@@ -9,8 +17,9 @@ let project = Project(
             product: .staticFramework,
             bundleId: "com.bitnagil.datasource",
             deploymentTargets: .iOS("15.0"),
-            infoPlist: .default,
+            infoPlist: .file(path: "Resources/Info.plist"),
             sources: ["Sources/**"],
+            resources: ["Resources/Secrets.xcconfig"],
             dependencies: [
                 .project(target: "Domain", path: "../Domain"),
                 .project(target: "Shared", path: "../Shared"),

--- a/Projects/DataSource/Resources/Info.plist
+++ b/Projects/DataSource/Resources/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BaseURL</key>
+	<string>$(BASE_URL)</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Projects/DataSource/Sources/DTO/BaseResponseDTO.swift
+++ b/Projects/DataSource/Sources/DTO/BaseResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  BaseResponseDTO.swift
+//  DataSource
+//
+//  Created by 최정인 on 6/23/25.
+//
+
+struct BaseResponseDTO<T: Decodable>: Decodable {
+    let code: String
+    let data: T
+    let message: String
+}

--- a/Projects/DataSource/Sources/DTO/HealthCheckRequestDTO.swift
+++ b/Projects/DataSource/Sources/DTO/HealthCheckRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  HealthCheckRequestDTO.swift
+//  DataSource
+//
+//  Created by 최정인 on 6/23/25.
+//
+
+import Foundation
+import Domain
+
+typealias HealthCheckRequestDTO = BaseResponseDTO<String>
+
+extension HealthCheckRequestDTO {
+    func toTestEntity() -> TestEntity {
+        let entity = TestEntity(message: message)
+        return entity
+    }
+}

--- a/Projects/DataSource/Sources/Endpoints/TestEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoints/TestEndpoint.swift
@@ -1,0 +1,37 @@
+//
+//  TestEndpoint.swift
+//  DataSource
+//
+//  Created by 최정인 on 6/21/25.
+//
+
+import Foundation
+
+enum TestEndpoint {
+    case healthCheck
+}
+
+extension TestEndpoint: Endpoint {
+    var baseURL: String {
+        return AppProperties.baseURL + "/api/v1/health-check"
+    }
+    
+    var path: String {
+        switch self {
+        case .healthCheck:
+            return baseURL
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .healthCheck: .get
+        }
+    }
+    
+    var headers: [String : String] {
+        return ["accept": "*/*"]
+    }
+
+    var parameters: [String : Any] { return [:] }
+}

--- a/Projects/DataSource/Sources/Network/AppProperties.swift
+++ b/Projects/DataSource/Sources/Network/AppProperties.swift
@@ -1,0 +1,18 @@
+//
+//  AppProperties.swift
+//  DataSource
+//
+//  Created by 최정인 on 6/23/25.
+//
+
+import Foundation
+
+enum AppProperties {
+    static var baseURL: String {
+        Bundle.module.object(forInfoDictionaryKey: "BaseURL") as? String ?? ""
+    }
+
+    static var test: String {
+        Bundle.module.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "네임 읽기 실패 ...."
+    }
+}

--- a/Projects/DataSource/Sources/Network/Endpoint.swift
+++ b/Projects/DataSource/Sources/Network/Endpoint.swift
@@ -1,0 +1,16 @@
+//
+//  Endpoint.swift
+//  DataSource
+//
+//  Created by 최정인 on 6/21/25.
+//
+
+import Foundation
+
+public protocol Endpoint {
+    var baseURL: String { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var headers: [String: String] { get }
+    var parameters: [String: Any] { get }
+}

--- a/Projects/DataSource/Sources/Network/HTTPMethod.swift
+++ b/Projects/DataSource/Sources/Network/HTTPMethod.swift
@@ -1,0 +1,14 @@
+//
+//  HTTPMethod.swift
+//  DataSource
+//
+//  Created by 최정인 on 6/21/25.
+//
+
+public enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+}

--- a/Projects/DataSource/Sources/Protocols/NetworkServiceProtocol.swift
+++ b/Projects/DataSource/Sources/Protocols/NetworkServiceProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  NetworkServiceProtocol.swift
+//  DataSource
+//
+//  Created by 최정인 on 6/20/25.
+//
+
+import Foundation
+
+public protocol NetworkServiceProtocol {
+    /// Endpoint로 비동기 네트워크 요청을 수행하고, 응답 데이터를 디코딩하여 반환합니다.
+    /// 네트워크 오류 또는 디코딩 오류가 발생한 경우, NetworkError를 throw 합니다.
+    ///
+    /// - Parameters:
+    ///   - endpoint: 요청을 보낼 API Endpoint 정보
+    ///   - type: 디코딩할 Response DTO 타입
+    /// - Returns: 응답 데이터를 디코딩한 객체
+    func request<T: Decodable>(endpoint: Endpoint, type: T.Type) async throws -> T
+}

--- a/Projects/DataSource/Sources/Repositories/TestRepository.swift
+++ b/Projects/DataSource/Sources/Repositories/TestRepository.swift
@@ -1,0 +1,25 @@
+//
+//  TestRepository.swift
+//  DataSource
+//
+//  Created by 최정인 on 6/21/25.
+//
+
+import Foundation
+import Domain
+
+public final class TestRepository: TestRepositoryProtocol {
+    private let networkService: NetworkServiceProtocol
+
+    public init(networkService: NetworkServiceProtocol) {
+        self.networkService = networkService
+    }
+
+    public func healthCheck() async throws -> TestEntity {
+        let response = try await networkService.request(
+            endpoint: TestEndpoint.healthCheck,
+            type: HealthCheckRequestDTO.self)
+
+        return response.toTestEntity()
+    }
+}

--- a/Projects/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Projects/Domain/Domain.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		032E4B53C9EDED3BCB584019 /* Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F491B7F514684708DC6E0D4 /* Domain.swift */; };
+		1CB61F792E706FBAD68A8533 /* TestRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7279CDAFEBE22BB17C441555 /* TestRepositoryProtocol.swift */; };
 		8952BE4BECBFDB70C6F5C838 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88290FF5D0840A64CDD73D68 /* Shared.framework */; };
+		97B47C308F0424EE944FF268 /* TestUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B04A8E13F160368F798C9B6 /* TestUseCase.swift */; };
+		CDE3B26AF208867C7AC94147 /* TestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358F73D87CCAC17578AE471A /* TestEntity.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,8 +27,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		358F73D87CCAC17578AE471A /* TestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEntity.swift; sourceTree = "<group>"; };
+		6B04A8E13F160368F798C9B6 /* TestUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUseCase.swift; sourceTree = "<group>"; };
+		7279CDAFEBE22BB17C441555 /* TestRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRepositoryProtocol.swift; sourceTree = "<group>"; };
 		88290FF5D0840A64CDD73D68 /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9F491B7F514684708DC6E0D4 /* Domain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Domain.swift; sourceTree = "<group>"; };
 		BD15A37E85BAE3A36B2CE72C /* Domain-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Domain-Info.plist"; sourceTree = "<group>"; };
 		FD49F277B86481D3D105FAC8 /* Domain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Domain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -43,12 +47,28 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0312E8562ED7D7FDA7627F90 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				6B04A8E13F160368F798C9B6 /* TestUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
 		0341B6BC3BB2B1CDE266CAF5 /* Derived */ = {
 			isa = PBXGroup;
 			children = (
 				BFC9D7B14C1B3B0AB857D8F2 /* InfoPlists */,
 			);
 			path = Derived;
+			sourceTree = "<group>";
+		};
+		1E26175B450A8825F000DB11 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				7279CDAFEBE22BB17C441555 /* TestRepositoryProtocol.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		23FB790DBB2E2B4343512188 /* Products */ = {
@@ -63,7 +83,9 @@
 		28B694539E22431DAF52B883 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				9F491B7F514684708DC6E0D4 /* Domain.swift */,
+				94B1D311211D6A02459E7B53 /* Entities */,
+				1E26175B450A8825F000DB11 /* Protocols */,
+				0312E8562ED7D7FDA7627F90 /* UseCases */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -83,6 +105,14 @@
 				28B694539E22431DAF52B883 /* Sources */,
 			);
 			name = Project;
+			sourceTree = "<group>";
+		};
+		94B1D311211D6A02459E7B53 /* Entities */ = {
+			isa = PBXGroup;
+			children = (
+				358F73D87CCAC17578AE471A /* TestEntity.swift */,
+			);
+			path = Entities;
 			sourceTree = "<group>";
 		};
 		BFC9D7B14C1B3B0AB857D8F2 /* InfoPlists */ = {
@@ -157,7 +187,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				032E4B53C9EDED3BCB584019 /* Domain.swift in Sources */,
+				CDE3B26AF208867C7AC94147 /* TestEntity.swift in Sources */,
+				1CB61F792E706FBAD68A8533 /* TestRepositoryProtocol.swift in Sources */,
+				97B47C308F0424EE944FF268 /* TestUseCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Projects/Domain/Sources/Entities/TestEntity.swift
+++ b/Projects/Domain/Sources/Entities/TestEntity.swift
@@ -1,0 +1,16 @@
+//
+//  TestEntity.swift
+//  Domain
+//
+//  Created by 최정인 on 6/23/25.
+//
+
+import Foundation
+
+public struct TestEntity {
+    public let message: String
+
+    public init(message: String) {
+        self.message = message
+    }
+}

--- a/Projects/Domain/Sources/Protocols/TestRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocols/TestRepositoryProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  TestRepositoryProtocol.swift
+//  Domain
+//
+//  Created by 최정인 on 6/23/25.
+//
+
+import Foundation
+
+public protocol TestRepositoryProtocol {
+    func healthCheck() async throws -> TestEntity
+}

--- a/Projects/Domain/Sources/UseCases/TestUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/TestUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  TestUseCase.swift
+//  Domain
+//
+//  Created by 최정인 on 6/23/25.
+//
+
+import Foundation
+import Shared
+
+public final class TestUseCase {
+    private let testRepository: TestRepositoryProtocol
+
+    public init(testRepository: TestRepositoryProtocol) {
+        self.testRepository = testRepository
+    }
+
+    public func healthCheck() async -> TestEntity? {
+        do {
+            let entity = try await testRepository.healthCheck()
+            return entity
+        } catch {
+            BitnagilLogger.log(logType: .error, message: error.localizedDescription)
+        }
+        return nil
+    }
+}

--- a/Projects/NetworkService/NetworkService.xcodeproj/project.pbxproj
+++ b/Projects/NetworkService/NetworkService.xcodeproj/project.pbxproj
@@ -8,7 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		0B7711A50A769C1EC9C89C0C /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C41C8487722085FEE05DE5 /* NetworkService.swift */; };
+		1D6C07C8F1BC217B376BD68C /* Endpoint+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654D509993123472BDECEEF0 /* Endpoint+.swift */; };
+		A0C23ED5966581DDC2CF7300 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A43BBDDB8A486DD0E067 /* NetworkError.swift */; };
 		A2C9E5DADF68F81C3CEF2A1D /* DataSource.framework in Dependencies */ = {isa = PBXBuildFile; fileRef = EA0240C54A9D5A70C45CE5CA /* DataSource.framework */; };
+		B7AD48CF464BD752348E08FD /* URLRequest+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D40330B1F74F59B45460876 /* URLRequest+.swift */; };
 		DEB5FF9533E7291594ADCC64 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5870AA60285FBE66073DD953 /* Shared.framework */; };
 /* End PBXBuildFile section */
 
@@ -37,9 +40,12 @@
 
 /* Begin PBXFileReference section */
 		5870AA60285FBE66073DD953 /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		654D509993123472BDECEEF0 /* Endpoint+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Endpoint+.swift"; sourceTree = "<group>"; };
+		7D40330B1F74F59B45460876 /* URLRequest+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+.swift"; sourceTree = "<group>"; };
 		90C41C8487722085FEE05DE5 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		ADC9183B12D666BFB5351F52 /* NetworkService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NetworkService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C463F8FAE8AE26DF76BDB73C /* NetworkService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "NetworkService-Info.plist"; sourceTree = "<group>"; };
+		C820A43BBDDB8A486DD0E067 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		EA0240C54A9D5A70C45CE5CA /* DataSource.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DataSource.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -66,6 +72,8 @@
 		38525DA2689C825D960A837C /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				C69C943FB685E38B8445E593 /* Extensions */,
+				C820A43BBDDB8A486DD0E067 /* NetworkError.swift */,
 				90C41C8487722085FEE05DE5 /* NetworkService.swift */,
 			);
 			path = Sources;
@@ -87,6 +95,15 @@
 				5870AA60285FBE66073DD953 /* Shared.framework */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		C69C943FB685E38B8445E593 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				654D509993123472BDECEEF0 /* Endpoint+.swift */,
+				7D40330B1F74F59B45460876 /* URLRequest+.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		EC532597712A1FBA04CFD78C /* InfoPlists */ = {
@@ -171,6 +188,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D6C07C8F1BC217B376BD68C /* Endpoint+.swift in Sources */,
+				B7AD48CF464BD752348E08FD /* URLRequest+.swift in Sources */,
+				A0C23ED5966581DDC2CF7300 /* NetworkError.swift in Sources */,
 				0B7711A50A769C1EC9C89C0C /* NetworkService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Projects/NetworkService/Sources/Extensions/Endpoint+.swift
+++ b/Projects/NetworkService/Sources/Extensions/Endpoint+.swift
@@ -1,0 +1,23 @@
+//
+//  Endpoint+.swift
+//  NetworkService
+//
+//  Created by 최정인 on 6/21/25.
+//
+
+import Foundation
+import DataSource
+
+extension Endpoint {
+    func makeURLRequest() throws -> URLRequest {
+        var request = try URLRequest(urlString: path)
+        request.httpMethod = method.rawValue
+        request.makeHeaders(headers: headers)
+        try request.makeParameters(
+            with: parameters,
+            method: method,
+            path: path)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        return request
+    }
+}

--- a/Projects/NetworkService/Sources/Extensions/URLRequest+.swift
+++ b/Projects/NetworkService/Sources/Extensions/URLRequest+.swift
@@ -1,0 +1,46 @@
+//
+//  URLRequest+.swift
+//  NetworkService
+//
+//  Created by 최정인 on 6/21/25.
+//
+
+import Foundation
+import DataSource
+
+extension URLRequest {
+    init(urlString: String) throws {
+        guard let url = URL(string: urlString) else {
+            throw NetworkError.invalidURL
+        }
+
+        self.init(url: url)
+    }
+
+    mutating func makeHeaders(headers: [String: String]) {
+        for header in headers {
+            addValue(header.value, forHTTPHeaderField: header.value)
+        }
+    }
+
+    mutating func makeParameters(
+        with parameters: [String: Any],
+        method: HTTPMethod,
+        path: String
+    ) throws {
+        switch method {
+        case .get:
+            guard var components = URLComponents(string: path) else {
+                throw NetworkError.invalidURL
+            }
+
+            components.queryItems = parameters.map {
+                URLQueryItem(name: $0.key, value: $0.value as? String)
+            }
+
+            try self = URLRequest(urlString: components.url?.absoluteString ?? "")
+        default:
+            httpBody = try JSONSerialization.data(withJSONObject: parameters)
+        }
+    }
+}

--- a/Projects/NetworkService/Sources/NetworkError.swift
+++ b/Projects/NetworkService/Sources/NetworkError.swift
@@ -1,0 +1,30 @@
+//
+//  NetworkError.swift
+//  NetworkService
+//
+//  Created by 최정인 on 6/23/25.
+//
+
+
+public enum NetworkError: Error, CustomStringConvertible {
+    case invalidURL
+    case invalidResponse
+    case invalidStatusCode(statusCode: Int)
+    case emptyData
+    case decodingError
+
+    public var description: String {
+        switch self {
+        case .invalidURL:
+            return "invalidURL"
+        case .invalidResponse:
+            return "invalidResponse"
+        case .invalidStatusCode(let statusCode):
+            return "\(statusCode)"
+        case .emptyData:
+            return "emptyData"
+        case .decodingError:
+            return "decodingError"
+        }
+    }
+}

--- a/Projects/NetworkService/Sources/NetworkService.swift
+++ b/Projects/NetworkService/Sources/NetworkService.swift
@@ -1,0 +1,39 @@
+//
+//  NetworkService.swift
+//  NetworkService
+//
+//  Created by 최정인 on 6/19/25.
+//
+
+import Foundation
+import DataSource
+
+public final class NetworkService: NetworkServiceProtocol {
+    private let session = URLSession.shared
+    private let decoder = JSONDecoder()
+
+    public init() { }
+
+    public func request<T: Decodable>(endpoint: Endpoint, type: T.Type) async throws -> T {
+        let request = try endpoint.makeURLRequest()
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+
+        guard 200..<300 ~= httpResponse.statusCode else {
+            throw NetworkError.invalidStatusCode(statusCode: httpResponse.statusCode)
+        }
+
+        guard !data.isEmpty else {
+            throw NetworkError.emptyData
+        }
+
+        guard let responseDTO = try? decoder.decode(T.self, from: data) else {
+            throw NetworkError.decodingError
+        }
+
+        return responseDTO
+    }
+}

--- a/Projects/Presentation/Sources/HomeViewController.swift
+++ b/Projects/Presentation/Sources/HomeViewController.swift
@@ -6,9 +6,22 @@
 //
 
 import UIKit
+import Domain
+import Shared
 
 public final class HomeViewController: UIViewController {
 
+    private let usecase: TestUseCase
+
+    public init(usecase: TestUseCase) {
+        self.usecase = usecase
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         configureAttribute()
@@ -17,9 +30,12 @@ public final class HomeViewController: UIViewController {
 
     private func configureAttribute() {
         view.backgroundColor = .blue
+        Task {
+            guard let entity = await usecase.healthCheck() else { return }
+            BitnagilLogger.log(logType: .debug, message: "\(entity.message)")
+        }
     }
 
     private func configureLayout() {
-
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
네트워크 통신 기능을 담당하는 NetworkService 모듈을 구현하였습니다.    


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- Endpoint 구현
- Network 통신을 위해 필요한 Enum 값 정의 (AppProperties, NetworkError, HTTPMethod ···)
- NetworkService 추상체 및 구현체 구현
- health-check로 개발 서버 테스트 (TestUseCase, TestRepository, ···)


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황
빌드 후 HomeViewController가 load 된 후 `configureAttribute()` 함수에서 네트워크를 수행합니다.     
현재 health-check API 테스트 진행 완료 하였습니다.

- 시나리오 진행에 필요한 조건
derived에 저장된 info.plist에 BaseURL 값이 존재해야 합니다.

- 시나리오 완료 시 보장하는 결과
Logger를 통해 health-check로 받은 response 값의 message 데이터가 출력됩니다.    

<img width="597" alt="스크린샷 2025-06-23 17 21 43" src="https://github.com/user-attachments/assets/f904a738-783a-4d17-9113-a9be46876055" />



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- App 모듈에서 의존성을 조립하기 위해 NetworkService, Persistence 모듈에 대한 의존성을 추가하였습니다.
- DI 조립하고 꺼내오는 부분을 더 고민해봐야 할 것 같습니다. 현재 테스트를 위해 SceneDelegate에서 임시로 강제 언래핑을 하여 값을 넘겨주고 있습니다. 추후 DI를 확정하면 해당 부분을 수정하겠습니다.
- 현재 네트워크 테스트를 위한 객체들이 많이 생성되어 있는 상황입니다. 기능 구현 시 해당 객체들은 삭제하겠습니다.



## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #T3-57
