### PR TITLE
[Feat] 빌드 체크 자동화 Github Actions 추가

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,48 @@
+name: iOS CI Build (Tuist + Secrets)
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Install Mise and Tuist
+        run: |
+          curl -fsSL https://mise.jdx.dev/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          mise install tuist
+          mise use -g tuist
+
+      - name: Generate xcconfig
+        run: |
+          mkdir -p SupportingFiles
+          echo "BASE_URL = ${BASE_URL}" > SupportingFiles/Secrets.xcconfig
+        env:
+          BASE_URL: ${{ secrets.BASE_URL }}
+
+      - name: Generate Xcode project with Tuist
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          mise exec -- tuist install
+          mise exec -- tuist generate --no-open
+
+      - name: Build with xcodebuild
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -workspace Bitnagil.xcworkspace \
+            -scheme App \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' \
+            clean build | xcpretty
+

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ iOSInjectionProject/
 **/Derived/
 .build/
 .cache/
+*.swp


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

빌드 자동화를 위해 Tuist와 Github Actions 기반의 CI 환경을 도입했습니다.  
해당 작업을 통해 develop 브랜치로 PR을 올릴 때 자동으로 빌드가 실행되고, 빌드 실패 시 바로 확인할 수 있도록 개선했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- Github Actions를 통해 develop으로 PR을 올릴 때마다 자동 빌드 환경 구축
- 빌드 실패 시 Github Actions가 실패로 처리되도록 설정


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- fork한 레포지토리를 통해 해당 Action이 잘 수행되는지 확인했습니다.
- 테스트한 환경은 다음과 같습니다.
    - 로컬에서 빌드 실패 시 Github Actions 실패 (테스트 완료 ✅)
    - 에러 수정 후 빌드 성공한 커밋을 푸시하여 Github Actions 성공 확인 (테스트 완료 ✅)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- Scerets.xcconfig 파일로 관리하고 있는 키 값들을 Repository Settings에 키-값 추가해줘야 합니다.


