### PR TITLE
[Feat] NetworkService 플러그인 구현

### DIFF
--- a/Projects/DataSource/Sources/NetworkService/NetworkError.swift
+++ b/Projects/DataSource/Sources/NetworkService/NetworkError.swift
@@ -5,12 +5,15 @@
 //  Created by 최정인 on 6/23/25.
 //
 
-enum NetworkError: Error, CustomStringConvertible {
+enum NetworkError: Error, CustomStringConvertible, Comparable {
     case invalidURL
     case invalidResponse
     case invalidStatusCode(statusCode: Int)
     case emptyData
     case decodingError
+    case needRetry
+    case noRetry
+    case unknown(description: String)
 
     var description: String {
         switch self {
@@ -24,6 +27,12 @@ enum NetworkError: Error, CustomStringConvertible {
             return "emptyData"
         case .decodingError:
             return "decodingError"
+        case .needRetry:
+            return "request need retry"
+        case .noRetry:
+            return "request don't need retry"
+        case .unknown(let description):
+            return "unknown error: \(description)"
         }
     }
 }

--- a/Projects/DataSource/Sources/NetworkService/NetworkService.swift
+++ b/Projects/DataSource/Sources/NetworkService/NetworkService.swift
@@ -30,7 +30,10 @@ final class NetworkService {
 
         while true {
             do {
-                return try await performRequest(endpoint: endpoint, type: type, withPlugins: withPlugins)
+                return try await performRequest(
+                    endpoint: endpoint,
+                    type: type,
+                    withPlugins: withPlugins)
             } catch let error as NetworkError {
                 guard
                     error == .needRetry,
@@ -65,7 +68,10 @@ final class NetworkService {
 
         if withPlugins {
             for plugin in plugins {
-                try await plugin.didReceive(response: response, data: data, endpoint: endpoint)
+                try await plugin.didReceive(
+                    response: response,
+                    data: data,
+                    endpoint: endpoint)
             }
         }
 

--- a/Projects/DataSource/Sources/NetworkService/NetworkService.swift
+++ b/Projects/DataSource/Sources/NetworkService/NetworkService.swift
@@ -11,8 +11,8 @@ import Shared
 final class NetworkService {
     static let shared = NetworkService()
     private let decoder = JSONDecoder()
-    private var plugins: [NetworkPlugin] = []
-    private var maxRetryCount = 0
+    private let plugins: [NetworkPlugin]
+    private let maxRetryCount = 1
 
     private init() {
         plugins = [

--- a/Projects/DataSource/Sources/NetworkService/NetworkService.swift
+++ b/Projects/DataSource/Sources/NetworkService/NetworkService.swift
@@ -11,16 +11,63 @@ import Shared
 final class NetworkService {
     static let shared = NetworkService()
     private let decoder = JSONDecoder()
+    private var plugins: [NetworkPlugin] = []
+    private var maxRetryCount = 0
 
-    private init() { }
+    private init() {
+        plugins = [
+            TokenInjectionPlugin(),
+            RefreshTokenPlugin(),
+            RetryPlugin()]
+    }
 
-    func request<T: Decodable>(endpoint: Endpoint, type: T.Type) async throws -> T? {
-        var request = try endpoint.makeURLRequest()
-        if endpoint.isAuthorized {
-            let accessToken = try TokenManager.shared.loadToken(tokenType: .accessToken)
-            request.headers["Authorization"] = "Bearer \(accessToken)"
+    func request<T: Decodable>(
+        endpoint: Endpoint,
+        type: T.Type,
+        withPlugins: Bool = true
+    ) async throws -> T? {
+        var retryCount = 0
+
+        while true {
+            do {
+                return try await performRequest(endpoint: endpoint, type: type, withPlugins: withPlugins)
+            } catch let error as NetworkError {
+                guard
+                    error == .needRetry,
+                    retryCount < maxRetryCount
+                else { throw error }
+
+                retryCount += 1
+                continue
+            }
         }
+    }
+
+    private func performRequest<T: Decodable>(
+        endpoint: Endpoint,
+        type: T.Type,
+        withPlugins: Bool = true
+    ) async throws -> T? {
+        var request = try endpoint.makeURLRequest()
+
+        if withPlugins {
+            for plugin in plugins {
+                request = try await plugin.willSend(request: request, endpoint: endpoint)
+            }
+        }
+
         let (data, response) = try await URLSession.shared.data(for: request)
+
+        // TODO: - 로깅 로직 수정
+        if let httpResponse = response as? HTTPURLResponse {
+            BitnagilLogger.log(logType: .info, message: "응답 코드: \(httpResponse.statusCode)")
+        }
+
+        if withPlugins {
+            for plugin in plugins {
+                try await plugin.didReceive(response: response, data: data, endpoint: endpoint)
+            }
+        }
 
         guard let httpResponse = response as? HTTPURLResponse
         else { throw NetworkError.invalidResponse }
@@ -39,7 +86,7 @@ final class NetworkService {
 
             guard let responseDTO = baseResponse.data
             else { return nil }
-            
+
             return responseDTO
         } catch {
             throw NetworkError.decodingError

--- a/Projects/DataSource/Sources/NetworkService/Plugin/RefreshTokenPlugin.swift
+++ b/Projects/DataSource/Sources/NetworkService/Plugin/RefreshTokenPlugin.swift
@@ -43,6 +43,7 @@ struct RefreshTokenPlugin: NetworkPlugin {
             BitnagilLogger.log(logType: .debug, message: "RefreshToken Saved: \(tokenResponse.refreshToken)")
         } catch {
             BitnagilLogger.log(logType: .error, message: "\(error.localizedDescription)")
+            throw error
         }
     }
 }

--- a/Projects/DataSource/Sources/NetworkService/Plugin/RefreshTokenPlugin.swift
+++ b/Projects/DataSource/Sources/NetworkService/Plugin/RefreshTokenPlugin.swift
@@ -1,0 +1,48 @@
+//
+//  RefreshTokenPlugin.swift
+//  DataSource
+//
+//  Created by 이동현 on 7/29/25.
+//
+
+import Foundation
+import Shared
+
+struct RefreshTokenPlugin: NetworkPlugin {
+    func willSend(request: URLRequest, endpoint: Endpoint) async throws -> URLRequest {
+        return request
+    }
+
+    func didReceive(response: URLResponse, data: Data?, endpoint: Endpoint) async throws {
+        guard
+            let httpResponse = response as? HTTPURLResponse,
+            httpResponse.statusCode == 401
+        else { return }
+
+
+        try await refreshAccessToken()
+    }
+
+    private func refreshAccessToken() async throws {
+        do {
+            let tokenManager = TokenManager.shared
+
+            let refreshToken = try tokenManager.loadToken(tokenType: .refreshToken)
+            let endpoint = AuthEndpoint.reissue(refreshToken: refreshToken)
+
+            guard let tokenResponse = try await NetworkService.shared.request(
+                endpoint: endpoint,
+                type: TokenResponseDTO.self,
+                withPlugins: false)
+            else { throw NetworkError.unknown(description: "토큰 갱신 실패") }
+
+            try tokenManager.saveToken(token: tokenResponse.accessToken, tokenType: .accessToken)
+            try tokenManager.saveToken(token: tokenResponse.refreshToken, tokenType: .refreshToken)
+
+            BitnagilLogger.log(logType: .debug, message: "AccessToken Saved: \(tokenResponse.accessToken)")
+            BitnagilLogger.log(logType: .debug, message: "RefreshToken Saved: \(tokenResponse.refreshToken)")
+        } catch {
+            BitnagilLogger.log(logType: .error, message: "\(error.localizedDescription)")
+        }
+    }
+}

--- a/Projects/DataSource/Sources/NetworkService/Plugin/RetryPlugin.swift
+++ b/Projects/DataSource/Sources/NetworkService/Plugin/RetryPlugin.swift
@@ -1,0 +1,31 @@
+//
+//  RetryPlugin.swift
+//  DataSource
+//
+//  Created by 이동현 on 7/29/25.
+//
+
+import Foundation
+
+struct RetryPlugin: NetworkPlugin {
+    func willSend(request: URLRequest, endpoint: Endpoint) async throws -> URLRequest {
+        return request
+    }
+
+    func didReceive(
+        response: URLResponse,
+        data: Data?,
+        endpoint: Endpoint
+    ) async throws {
+        guard let httpResponse = response as? HTTPURLResponse else { return }
+
+        switch httpResponse.statusCode {
+        case 200..<300:
+            return
+        case 401: // TODO: - 재전송 정책 필요시 조정하기!!
+            throw NetworkError.needRetry
+        default:
+            throw NetworkError.noRetry
+        }
+    }
+}

--- a/Projects/DataSource/Sources/NetworkService/Plugin/TokenInjectionPlugin.swift
+++ b/Projects/DataSource/Sources/NetworkService/Plugin/TokenInjectionPlugin.swift
@@ -1,0 +1,21 @@
+//
+//  TokenInjectionPlugin.swift
+//  DataSource
+//
+//  Created by 이동현 on 7/29/25.
+//
+
+import Foundation
+
+struct TokenInjectionPlugin: NetworkPlugin {
+    func willSend(request: URLRequest, endpoint: any Endpoint) async throws -> URLRequest {
+        guard endpoint.isAuthorized else { return request }
+
+        var newRequest = request
+        let accessToken = try TokenManager.shared.loadToken(tokenType: .accessToken)
+        newRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        return newRequest
+    }
+    
+    func didReceive(response: URLResponse, data: Data?, endpoint: any Endpoint) async throws {}
+}

--- a/Projects/DataSource/Sources/NetworkService/Protocol/NetworkPlugin.swift
+++ b/Projects/DataSource/Sources/NetworkService/Protocol/NetworkPlugin.swift
@@ -1,0 +1,27 @@
+//
+//  NetworkPlugin.swift
+//  DataSource
+//
+//  Created by 이동현 on 7/29/25.
+//
+
+import Foundation
+
+protocol NetworkPlugin {
+    /// 네트워크 요청 전처리를 진행합니다.
+    /// - Parameters:
+    ///   - request: 요청할 request 객체
+    ///   - endpoint: 요청할 엔드포인트
+    /// - Returns: URLRequest 객체
+    func willSend(request: URLRequest, endpoint: Endpoint) async throws -> URLRequest
+
+    /// 네트워크 응답 후처리를 진행합니다.
+    /// - Parameters:
+    ///   - response: URLResponse 객체
+    ///   - data: 통신 후 받은 데이터
+    ///   - endpoint: 요청한 endpoint
+    func didReceive(
+        response: URLResponse,
+        data: Data?,
+        endpoint: Endpoint) async throws
+}


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 기존 NetworkService이 토큰 주입, 요청 전송 등의 여러 책임을 가지고 있었습니다. 이에 네트워크 요청의 역할 분리 및 유연한 확장성을 위해 NetworkSerive의 구조를 아주 아주 약간 변경할 필요를 느꼈습니다.
- 
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- NetworkSerivce에 적용할 수 있는 NetworkPlugin 구현
    - 토큰 주입 플러그인
    - 토큰 갱신 플러그인
    - 요청 재전송 정책 관리 플러그인
- NetworkService에 플러그인 적용


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
### NetworkPlugin 구조
```swift
protocol NetworkPlugin {
    /// 네트워크 요청 전처리를 진행합니다.
    /// - Parameters:
    ///   - request: 요청할 request 객체
    ///   - endpoint: 요청할 엔드포인트
    /// - Returns: URLRequest 객체
    func willSend(request: URLRequest, endpoint: Endpoint) async throws -> URLRequest

    /// 네트워크 응답 후처리를 진행합니다.
    /// - Parameters:
    ///   - response: URLResponse 객체
    ///   - data: 통신 후 받은 데이터
    ///   - endpoint: 요청한 endpoint
    func didReceive(
        response: URLResponse,
        data: Data?,
        endpoint: Endpoint) async throws
}
```
플러그인은 네트워크 요청의 **전처리(willSend)** 와 **후처리(didReceive)** 를 담당하는 구조로 설계되었습니다.
`NetworkService`는 등록된 플러그인들의 `willSend`, `didReceive`를 순차적으로 실행하여 네트워크 요청의 확장성과 유연성을 확보합니다.

### 고민했던 점 및 구조 설계 의도
1. 플러그인(Plugin) 기반의 네트워크 확장성
- `NetworkPlugin 프로토콜`을 채택한 플러그인은 언제든지 `NetworkService`에 추가/제거할 수 있어, 요청 전처리(willSend), 응답 후처리(didReceive)를 유연하게 조합할 수 있습니다.
- 기본적인 요청 흐름은 아래와 같습니다. (request 함수의 withPlugins 값이 true인 경우) 
    1. plugins 배열 안에 등록된 플러그인의 `willSend` 함수들을 등록 순서대로 순차적으로 실행하여, `URLRequest`를 가공합니다.
    2.	가공한 `URLRequest`로 네트워크 요청을 전송합니다.
    3. 응답을 받은 뒤, plugins 배열 안의 `didReceive` 함수들을 역시 등록 순서대로 실행하여, `URLResponse`를 분석하고 후처리를 진행합니다.

‼️중요‼️: 플러그인의 추가 순서대로 각각 willSend와 didReceive가 실행되므로, 요청의 흐름을 설계할 때 **플러그인 등록 순서를 신경 써야** 합니다. (ex. 아래와 같은 순서로 추가)
```swift
        plugins = [
            TokenInjectionPlugin(),
            RefreshTokenPlugin(),
            RetryPlugin()]
```
- 위 경우는 **토큰 주입 → 401 발생 시 토큰 갱신 → 재전송 정책 확인 후 필요 시 재요청** 이 순서대로 일어나게 됩니다.

2. 네트워크 재전송 플러그인(RetryPlugin)
- 처음에는 플러그인 내부에서 직접 재전송 로직까지 처리할지 고민했지만, 플러그인의 역할은 정책 결정에 집중하고, 실제 네트워크 요청의 실행은 `NetworkService`에서 관리하는 것이 관심사의 분리 측면에서 더 적합하다고 판단했습니다.
- 따라서 `RetryPlugin`은 단순히 응답에 따라 재시도 필요 여부(needRetry, noRetry)만 판단하고, `NetworkService`가 이 값을 받아 실제로 재요청을 처리합니다.

3. 토큰 갱신 플러그인(RefreshTokenPlugin)과 withPlugins 파라미터
- RefreshTokenPlugin은 401 에러(인증 실패) 시 토큰 갱신을 담당합니다.
- 플러그인 내부에서 NetworkService를 사용해 토큰을 갱신하도록 했는데, 이 경우 [NetworkService → 플러그인 → NetworkService… ]와 같이 **무한루프가** 발생할 수 있다는 문제를 인지했습니다.
- 이를 방지하기 위해 NetworkService의 request 메서드에 withPlugins 플래그를 추가하여 플러그인 없이 네트워크 요청을 전송할 수 있도록 구현했습니다.
- 사실 플래그를 추가하고 난 다음에 느낀 장점(의도하고 추가한건 아니지만 ㅎㅎ..)으로, 토큰 갱신뿐 아니라 추후 ‘플러그인을 사용하지 않아야 하는 특수한 네트워크 요청’에도 유연하게 대응할 수 있게 되었다는 점이 있습니다. (ex. 플러그인을 통해 헤더가 임의로 수정되면 안 되는 API 요청 등)
- 또한 현재는 NetworkService가 싱글톤으로 동작하지만, 요청마다 사용하는 플러그인이 달라져야 할 경우에는 싱글톤이 아닌 인스턴스화 구조로 변경하면 쉽게 대응할 수 있다고 생각합니다.

### 데스노트 1번: 로깅이 정상적으로 일어나도록 로직 정리
- 현재 요청 전송 이후 didReceive로 후처리를 하는 과정에서 오류를 throw할 시, 해당 로직 아래의 로깅 부분이 실행되지 않는 문제가 있었습니다. 처음에 이 문제를 파악하지 못해서 정상적으로 카카오 로그인이 진행되고 있음에도, 로깅을 진행하지 못해 오류를 찾아내는데 많은 시간이 들었습니다 (따흑,,ㅠ) 
```swift
       // 아래 있는 1번 주석의 흐름이 먼저입니다!!

       // 2. 그래서 일단 급하게 요 부분에 didReceive 이전에 로깅할 수 있는 로직을 추가함 
        if let httpResponse = response as? HTTPURLResponse {
            BitnagilLogger.log(logType: .info, message: "응답 코드: \(httpResponse.statusCode)")
        }

        if withPlugins {
            for plugin in plugins {
                try await plugin.didReceive(response: response, data: data, endpoint: endpoint)
            }
        }
       // 1. 이 아래 부분이 실행되지 않는 문제가 있었음!!!!!!!! 그래서 
        guard let httpResponse = response as? HTTPURLResponse
        else { throw NetworkError.invalidResponse }

        guard 200..<300 ~= httpResponse.statusCode else {
            BitnagilLogger.log(logType: .error, message: "응답 코드: \(httpResponse.statusCode)")
            throw NetworkError.invalidStatusCode(statusCode: httpResponse.statusCode)
        }
```
- 현재 계획중인 방법으로, 네트워크 응답을 로깅하는 로직도 플러그인으로 빼버릴까 합니다. 오히려 NetworkService는 로깅에 신경 쓸 필요가 없어지니까 더 컴팩트한 구조로 갈 수 있지 않을까 합니다~

### 데스노트 2번: 플러그인 의존성 관리
- 일단 요 부분도 급해서 집어넣긴 했는데요, 현재 따로 Plugin 의존성을 주입받고 있지는 않고 생성자에서 집어 넣고 있습니다.
- 아주 큰 문제는 아니지만, 의존성 주입을 생성자로 하는게 나을지, setter 주입으로 하는게 나을지 고민이 되는데 조이는 어떤 방법이 낫다 생각 하시나요? (요 부분에 따라서 plugins 배열을 var로 갈지, let으로 갈 지 선택할 것 같습니다! 물론 지금처럼 생성자 안에서 plugin을 넣어주면 let이 맞겠죠!!!!!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 네트워크 요청에 플러그인 기반 라이프사이클 도입 및 자동 재시도 기능 추가
  * 토큰 자동 주입, 토큰 갱신, 재시도 플러그인 추가로 네트워크 요청 처리 개선
  * 네트워크 오류 유형 확장 및 상세 오류 메시지 제공

* **버그 수정**
  * 인증 헤더 주입 방식 개선(플러그인으로 대체)

* **문서화**
  * 네트워크 플러그인 프로토콜 및 각 플러그인 역할 명확화

* **리팩터링**
  * 네트워크 요청 처리 구조를 플러그인 기반으로 변경하여 유지보수성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->