### PR TITLE
[Feat] 루틴 등록 / 수정 로직 구현

### DIFF
--- a/Projects/DataSource/Sources/Common/Extension/Encodable+.swift
+++ b/Projects/DataSource/Sources/Common/Extension/Encodable+.swift
@@ -1,0 +1,18 @@
+//
+//  Encodable+.swift
+//  DataSource
+//
+//  Created by 이동현 on 8/3/25.
+//
+
+import Foundation
+
+extension Encodable {
+    var dictionary: [String: Any] {
+        guard
+            let data = try? JSONEncoder().encode(self),
+            let dictionary = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [:] }
+        return dictionary
+    }
+}

--- a/Projects/DataSource/Sources/DTO/RoutienCreationDTO.swift
+++ b/Projects/DataSource/Sources/DTO/RoutienCreationDTO.swift
@@ -1,0 +1,13 @@
+//
+//  RoutienCreationDTO.swift
+//  DataSource
+//
+//  Created by 이동현 on 8/3/25.
+//
+
+struct RoutienCreationDTO: Codable {
+    let routineName: String
+    let repeatDay: [String]
+    let executionTime: String
+    let subRoutineName: [String]
+}

--- a/Projects/DataSource/Sources/DTO/RoutineCreationDTO.swift
+++ b/Projects/DataSource/Sources/DTO/RoutineCreationDTO.swift
@@ -5,7 +5,7 @@
 //  Created by 이동현 on 8/3/25.
 //
 
-struct RoutienCreationDTO: Codable {
+struct RoutineCreationDTO: Codable {
     let routineName: String
     let repeatDay: [String]
     let executionTime: String

--- a/Projects/DataSource/Sources/DTO/RoutineResponseDTO.swift
+++ b/Projects/DataSource/Sources/DTO/RoutineResponseDTO.swift
@@ -26,13 +26,15 @@ struct RoutineResponseDTO: Decodable {
 
 extension RoutineResponseDTO {
     func toRoutineEntity() -> RoutineEntity {
+        let sortedSubRoutinesDTO = subRoutineSearchResultDto.sorted { $0.sortOrder < $1.sortOrder }
+
         return RoutineEntity(
             routineId: routineId,
             historySeq: historySeq,
             routineName: routineName,
             repeatDay: repeatDay,
             executionTime: executionTime,
-            subRoutineSearchResultDto: subRoutineSearchResultDto.map({ $0.toSubRoutineEntity() }),
+            subRoutineSearchResultDto: sortedSubRoutinesDTO.map({ $0.toSubRoutineEntity() }),
             modifiedYn: modifiedYn,
             routineCompletionId: routineCompletionId,
             completeYn: completeYn,

--- a/Projects/DataSource/Sources/DTO/RoutineUpdateDTO.swift
+++ b/Projects/DataSource/Sources/DTO/RoutineUpdateDTO.swift
@@ -1,0 +1,14 @@
+//
+//  RoutineUpdateDTO.swift
+//  DataSource
+//
+//  Created by 이동현 on 8/3/25.
+//
+
+struct RoutineUpdateDTO: Codable {
+    let routineId: String
+    let routineName: String
+    let repeatDay: [String]
+    let executionTime: String
+    let subRoutineInfos: [SubRoutineUpdateDTO]
+}

--- a/Projects/DataSource/Sources/DTO/SubRoutineUpdateDTO.swift
+++ b/Projects/DataSource/Sources/DTO/SubRoutineUpdateDTO.swift
@@ -1,0 +1,12 @@
+//
+//  SubRoutineUpdateDTO.swift
+//  DataSource
+//
+//  Created by 이동현 on 8/3/25.
+//
+
+struct SubRoutineUpdateDTO: Codable {
+    let subRoutineId: String
+    let subRoutineName: String?
+    let sortOrder: Int?
+}

--- a/Projects/DataSource/Sources/DTO/SubRoutineUpdateDTO.swift
+++ b/Projects/DataSource/Sources/DTO/SubRoutineUpdateDTO.swift
@@ -6,7 +6,7 @@
 //
 
 struct SubRoutineUpdateDTO: Codable {
-    let subRoutineId: String
+    let subRoutineId: String?
     let subRoutineName: String?
     let sortOrder: Int?
 }

--- a/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
@@ -6,7 +6,10 @@
 //
 
 enum RoutineEndpoint {
+    case createRoutine(routine: RoutienCreationDTO)
+    case fetchRoutine(routineId: String)
     case fetchRoutines(startDate: String, endDate: String)
+    case updateRoutine(routine: RoutineUpdateDTO)
 }
 
 extension RoutineEndpoint: Endpoint {
@@ -16,13 +19,21 @@ extension RoutineEndpoint: Endpoint {
 
     var path: String {
         switch self {
-        case .fetchRoutines: baseURL
+        case .fetchRoutine(let routineId):
+            "\(routineId)"
+        default:
+            baseURL
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .fetchRoutines: .get
+        case .createRoutine:
+                .post
+        case .fetchRoutine, .fetchRoutines:
+                .get
+        case .updateRoutine:
+                .patch
         }
     }
     
@@ -40,11 +51,20 @@ extension RoutineEndpoint: Endpoint {
             return [
                 "startDate": startDate,
                 "endDate": endDate]
+        default:
+            return [:]
         }
     }
     
     var bodyParameters: [String : Any] {
-        return [:]
+        switch self {
+        case .createRoutine(let routine):
+            return routine.dictionary
+        case .updateRoutine(let routine):
+            return routine.dictionary
+        default:
+            return [:]
+        }
     }
     
     var isAuthorized: Bool {

--- a/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
@@ -6,7 +6,7 @@
 //
 
 enum RoutineEndpoint {
-    case createRoutine(routine: RoutienCreationDTO)
+    case createRoutine(routine: RoutineCreationDTO)
     case fetchRoutine(routineId: String)
     case fetchRoutines(startDate: String, endDate: String)
     case updateRoutine(routine: RoutineUpdateDTO)

--- a/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
@@ -20,7 +20,7 @@ extension RoutineEndpoint: Endpoint {
     var path: String {
         switch self {
         case .fetchRoutine(let routineId):
-            "\(routineId)"
+            "\(baseURL)/\(routineId)"
         default:
             baseURL
         }

--- a/Projects/DataSource/Sources/Repository/RoutineRepository.swift
+++ b/Projects/DataSource/Sources/Repository/RoutineRepository.swift
@@ -10,12 +10,14 @@ import Domain
 final class RoutineRepository: RoutineRepositoryProtocol {
     private let networkService = NetworkService.shared
 
-    func createRoutine(routine: RoutineEntity) async throws {
+    func createRoutine(routineSummary: RoutineSummaryEntity, subRoutineSummaries: [SubRoutineSummaryEntity]) async throws {
+        let subRoutineNames = subRoutineSummaries.compactMap { $0.subRoutineName }
+
         let routineCreationDTO = RoutineCreationDTO(
-            routineName: routine.routineName,
-            repeatDay: routine.repeatDay.map { $0.rawValue },
-            executionTime: routine.executionTime,
-            subRoutineName: routine.subRoutineSearchResultDto.map { $0.subRoutineName })
+            routineName: routineSummary.routineName,
+            repeatDay: routineSummary.repeatDay.map { $0.rawValue },
+            executionTime: routineSummary.executionTime,
+            subRoutineName: subRoutineNames)
         let endpoint = RoutineEndpoint.createRoutine(routine: routineCreationDTO)
 
         _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
@@ -40,24 +42,24 @@ final class RoutineRepository: RoutineRepositoryProtocol {
         return result
     }
 
-    func updateRoutine(routine: Domain.RoutineEntity) async throws {
-        guard let routineId = routine.routineId else { return }
-        
-        let subRoutines = routine
-            .subRoutineSearchResultDto
-            .map {
-                SubRoutineUpdateDTO(
-                    subRoutineId: $0.subRoutineId ?? "",
-                    subRoutineName: $0.subRoutineName,
-                    sortOrder: $0.sortOrder)}
+    func updateRoutine(routineSummary: RoutineSummaryEntity, subRoutineSummaries: [SubRoutineSummaryEntity]) async throws {
+        guard let routineId = routineSummary.routineId else { return }
+
+        let subRoutineDTO = subRoutineSummaries.map {
+            SubRoutineUpdateDTO(
+                subRoutineId: $0.subRoutineId,
+                subRoutineName: $0.subRoutineName,
+                sortOrder: $0.sortOrder)
+        }
+
         let routineUpdateDTO = RoutineUpdateDTO(
             routineId: routineId,
-            routineName: routine.routineName,
-            repeatDay: routine.repeatDay.map { $0.rawValue },
-            executionTime: routine.executionTime,
-            subRoutineInfos: subRoutines)
+            routineName: routineSummary.routineName,
+            repeatDay: routineSummary.repeatDay.map { $0.rawValue },
+            executionTime: routineSummary.executionTime,
+            subRoutineInfos: subRoutineDTO)
         let endpoint = RoutineEndpoint.updateRoutine(routine: routineUpdateDTO)
-        
+
         _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
     }
 }

--- a/Projects/DataSource/Sources/Repository/RoutineRepository.swift
+++ b/Projects/DataSource/Sources/Repository/RoutineRepository.swift
@@ -10,6 +10,24 @@ import Domain
 final class RoutineRepository: RoutineRepositoryProtocol {
     private let networkService = NetworkService.shared
 
+    func createRoutine(routine: RoutineEntity) async throws {
+        let routineCreationDTO = RoutineCreationDTO(
+            routineName: routine.routineName,
+            repeatDay: routine.repeatDay.map { $0.rawValue },
+            executionTime: routine.executionTime,
+            subRoutineName: routine.subRoutineSearchResultDto.map { $0.subRoutineName })
+        let endpoint = RoutineEndpoint.createRoutine(routine: routineCreationDTO)
+
+        _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
+    }
+    
+    func fetchRoutine(routineId: String) async throws -> RoutineEntity? {
+        let endpoint = RoutineEndpoint.fetchRoutine(routineId: routineId)
+        guard let response = try await networkService.request(endpoint: endpoint, type: RoutineResponseDTO.self) else { return nil }
+        
+        return response.toRoutineEntity()
+    }
+
     func fetchRoutines(from startDate: String, to endDate: String) async throws -> [String: [RoutineEntity]] {
         let endpoint = RoutineEndpoint.fetchRoutines(startDate: startDate, endDate: endDate)
         guard let response = try await networkService.request(endpoint: endpoint, type: RoutineDictionaryDTO.self)
@@ -20,5 +38,26 @@ final class RoutineRepository: RoutineRepositoryProtocol {
             result[date] = routineDTO.compactMap({ $0.toRoutineEntity() })
         }
         return result
+    }
+
+    func updateRoutine(routine: Domain.RoutineEntity) async throws {
+        guard let routineId = routine.routineId else { return }
+        
+        let subRoutines = routine
+            .subRoutineSearchResultDto
+            .map {
+                SubRoutineUpdateDTO(
+                    subRoutineId: $0.subRoutineId ?? "",
+                    subRoutineName: $0.subRoutineName,
+                    sortOrder: $0.sortOrder)}
+        let routineUpdateDTO = RoutineUpdateDTO(
+            routineId: routineId,
+            routineName: routine.routineName,
+            repeatDay: routine.repeatDay.map { $0.rawValue },
+            executionTime: routine.executionTime,
+            subRoutineInfos: subRoutines)
+        let endpoint = RoutineEndpoint.updateRoutine(routine: routineUpdateDTO)
+        
+        _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
     }
 }

--- a/Projects/Domain/Sources/Entity/Enum/WeekType.swift
+++ b/Projects/Domain/Sources/Entity/Enum/WeekType.swift
@@ -1,0 +1,16 @@
+//
+//  Week.swift
+//  Domain
+//
+//  Created by 이동현 on 8/3/25.
+//
+
+public enum WeekType: String, CaseIterable {
+    case monday = "MONDAY"
+    case tuesday = "TUESDAY"
+    case wednesday = "WEDNESDAY"
+    case thursday = "THURSDAY"
+    case friday = "FRIDAY"
+    case saturday = "SATURDAY"
+    case sunday = "SUNDAY"
+}

--- a/Projects/Domain/Sources/Entity/RoutineEntity.swift
+++ b/Projects/Domain/Sources/Entity/RoutineEntity.swift
@@ -18,7 +18,7 @@ public struct RoutineEntity {
     public let routineType: String
 
     public init(
-        routineId: String,
+        routineId: String?,
         historySeq: Int,
         routineName: String,
         repeatDay: [String]?,

--- a/Projects/Domain/Sources/Entity/RoutineEntity.swift
+++ b/Projects/Domain/Sources/Entity/RoutineEntity.swift
@@ -6,7 +6,7 @@
 //
 
 public struct RoutineEntity {
-    public let routineId: String
+    public let routineId: String?
     public let historySeq: Int
     public let routineName: String
     public let repeatDay: [String]

--- a/Projects/Domain/Sources/Entity/RoutineEntity.swift
+++ b/Projects/Domain/Sources/Entity/RoutineEntity.swift
@@ -9,7 +9,7 @@ public struct RoutineEntity {
     public let routineId: String?
     public let historySeq: Int
     public let routineName: String
-    public let repeatDay: [String]
+    public let repeatDay: [WeekType]
     public let executionTime: String
     public let subRoutineSearchResultDto: [SubRoutineEntity]
     public let modifiedYn: Bool
@@ -29,10 +29,12 @@ public struct RoutineEntity {
         completeYn: Bool,
         routineType: String
     ) {
+        let weekType: [WeekType] = repeatDay?.compactMap(WeekType.init(rawValue:)) ?? []
+
         self.routineId = routineId
         self.historySeq = historySeq
         self.routineName = routineName
-        self.repeatDay = repeatDay ?? []
+        self.repeatDay = weekType
         self.executionTime = executionTime
         self.subRoutineSearchResultDto = subRoutineSearchResultDto
         self.modifiedYn = modifiedYn

--- a/Projects/Domain/Sources/Entity/RoutineSummaryEntity.swift
+++ b/Projects/Domain/Sources/Entity/RoutineSummaryEntity.swift
@@ -1,0 +1,27 @@
+//
+//  RoutineSummaryEntity.swift
+//  Domain
+//
+//  Created by 이동현 on 8/3/25.
+//
+
+public struct RoutineSummaryEntity {
+    public let routineId: String?
+    public let routineName: String
+    public let repeatDay: [WeekType]
+    public let executionTime: String
+
+    public init(
+        routineId: String?,
+        routineName: String,
+        repeatDay: [String]?,
+        executionTime: String
+    ) {
+        let weekType: [WeekType] = repeatDay?.compactMap(WeekType.init(rawValue:)) ?? []
+
+        self.routineId = routineId
+        self.routineName = routineName
+        self.repeatDay = weekType
+        self.executionTime = executionTime
+    }
+}

--- a/Projects/Domain/Sources/Entity/SubRoutineEntity.swift
+++ b/Projects/Domain/Sources/Entity/SubRoutineEntity.swift
@@ -6,7 +6,7 @@
 //
 
 public struct SubRoutineEntity: Decodable {
-    public let subRoutineId: String
+    public let subRoutineId: String?
     public let historySeq: Int
     public let subRoutineName: String
     public let modifiedYn: Bool

--- a/Projects/Domain/Sources/Entity/SubRoutineSummaryEntity.swift
+++ b/Projects/Domain/Sources/Entity/SubRoutineSummaryEntity.swift
@@ -1,0 +1,22 @@
+//
+//  SubRoutineSummaryEntity.swift
+//  Domain
+//
+//  Created by 이동현 on 8/3/25.
+//
+
+public struct SubRoutineSummaryEntity: Decodable {
+    public let subRoutineId: String?
+    public let subRoutineName: String?
+    public let sortOrder: Int?
+
+    public init(
+        subRoutineId: String?,
+        subRoutineName: String?,
+        sortOrder: Int?
+    ) {
+        self.subRoutineId = subRoutineId
+        self.subRoutineName = subRoutineName
+        self.sortOrder = sortOrder
+    }
+}

--- a/Projects/Domain/Sources/Entity/SubRoutineSummaryEntity.swift
+++ b/Projects/Domain/Sources/Entity/SubRoutineSummaryEntity.swift
@@ -5,7 +5,7 @@
 //  Created by 이동현 on 8/3/25.
 //
 
-public struct SubRoutineSummaryEntity: Decodable {
+public struct SubRoutineSummaryEntity: Decodable, Hashable {
     public let subRoutineId: String?
     public let subRoutineName: String?
     public let sortOrder: Int?

--- a/Projects/Domain/Sources/Entity/Untitled.swift
+++ b/Projects/Domain/Sources/Entity/Untitled.swift
@@ -1,0 +1,7 @@
+//
+//  Untitled.swift
+//  Domain
+//
+//  Created by 이동현 on 8/3/25.
+//
+

--- a/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
@@ -7,9 +7,22 @@
 
 // 루틴 관련 로직(조회, 완료, 등록, 삭제 등)을 수행하는 Repository
 public protocol RoutineRepositoryProtocol {
-    /// 루틴을 조회합니다. (기간)
+    /// 루틴을 생성합니다.
+    /// - Parameter routine: 생성할 루틴
+    func createRoutine(routine: RoutineEntity) async throws
+
+    /// 루틴을 조회합니다.
+    /// - Parameter routineId: 조회할 루틴 id
+    /// - Returns: 조회된 루틴
+    func fetchRoutine(routineId: String) async throws -> RoutineEntity?
+
+    /// 루틴 목록을 조회합니다. (기간)
     /// - Parameters:
     ///   - startDate: 조회 시작 날짜
     ///   - endDate: 조회 종료 날짜
     func fetchRoutines(from startDate: String, to endDate: String) async throws -> [String: [RoutineEntity]]
+
+    /// 루틴을 수정합니다.
+    /// - Parameter routine: 수정할 루틴
+    func updateRoutine(routine: RoutineEntity) async throws
 }

--- a/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
@@ -8,8 +8,10 @@
 // 루틴 관련 로직(조회, 완료, 등록, 삭제 등)을 수행하는 Repository
 public protocol RoutineRepositoryProtocol {
     /// 루틴을 생성합니다.
-    /// - Parameter routine: 생성할 루틴
-    func createRoutine(routine: RoutineEntity) async throws
+    /// - Parameters:
+    ///   - routineSummary: 루틴 요약 정보
+    ///   - subRoutineSummaries: 서브 루틴 요약 정보 배열
+    func createRoutine(routineSummary: RoutineSummaryEntity, subRoutineSummaries: [SubRoutineSummaryEntity]) async throws
 
     /// 루틴을 조회합니다.
     /// - Parameter routineId: 조회할 루틴 id
@@ -22,7 +24,10 @@ public protocol RoutineRepositoryProtocol {
     ///   - endDate: 조회 종료 날짜
     func fetchRoutines(from startDate: String, to endDate: String) async throws -> [String: [RoutineEntity]]
 
+
     /// 루틴을 수정합니다.
-    /// - Parameter routine: 수정할 루틴
-    func updateRoutine(routine: RoutineEntity) async throws
+    /// - Parameters:
+    ///   - routineSummary: 루틴 요약 정보
+    ///   - subRoutineSummaries: 서브 루틴 요약 정보 배열
+    func updateRoutine(routineSummary: RoutineSummaryEntity, subRoutineSummaries: [SubRoutineSummaryEntity]) async throws
 }

--- a/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
@@ -8,5 +8,13 @@
 import Foundation
 
 public protocol RoutineUseCaseProtocol {
+    func fetchRoutine(routineId: String) async throws -> RoutineEntity?
+
     func fetchRoutines(startDate: Date, endDate: Date) async throws -> [String: [RoutineEntity]]
+
+    func saveRoutine(
+        routineSummary: RoutineSummaryEntity,
+        subRoutineSummaries: [SubRoutineSummaryEntity],
+        deletedSubRoutineSummaries: [SubRoutineSummaryEntity]
+    ) async throws
 }

--- a/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
@@ -15,11 +15,59 @@ public final class RoutineUseCase: RoutineUseCaseProtocol {
         self.routineRepository = routineRepository
     }
 
+    public func fetchRoutine(routineId: String) async throws -> RoutineEntity? {
+        let routineEnity = try await routineRepository.fetchRoutine(routineId: routineId)
+        return routineEnity
+    }
+
     public func fetchRoutines(startDate: Date, endDate: Date) async throws -> [String: [RoutineEntity]] {
         let start = startDate.convertToString(dateType: .yearMonthDate)
         let end = endDate.convertToString(dateType: .yearMonthDate)
 
         var routineEntities = try await routineRepository.fetchRoutines(from: start, to: end)
         return routineEntities
+    }
+
+    public func saveRoutine(
+        routineSummary: RoutineSummaryEntity,
+        subRoutineSummaries: [SubRoutineSummaryEntity],
+        deletedSubRoutineSummaries: [SubRoutineSummaryEntity]
+    ) async throws {
+        if let routineId = routineSummary.routineId { // 루틴 아이디가 있으면 수정, 없으면 생성
+            try await createRoutine(routineSummary: routineSummary, subRoutinesSummaries: subRoutineSummaries)
+        } else {
+            try await updateRoutine(
+                routineSummary: routineSummary,
+                subRoutineSummaries: subRoutineSummaries,
+                deletedSubRoutineSummaries: deletedSubRoutineSummaries)
+        }
+    }
+
+    private func createRoutine(routineSummary: RoutineSummaryEntity, subRoutinesSummaries: [SubRoutineSummaryEntity]) async throws {
+        try await routineRepository.createRoutine(routineSummary: routineSummary, subRoutineSummaries: subRoutinesSummaries)
+    }
+
+    private func updateRoutine(
+        routineSummary: RoutineSummaryEntity,
+        subRoutineSummaries: [SubRoutineSummaryEntity],
+        deletedSubRoutineSummaries: [SubRoutineSummaryEntity]
+    ) async throws {
+        let updatedSubRoutines = subRoutineSummaries
+            .enumerated()
+            .map {
+                SubRoutineSummaryEntity(
+                    subRoutineId: $1.subRoutineId,
+                    subRoutineName: $1.subRoutineName,
+                    sortOrder: $0 + 1)
+            }
+        let deletedSubRoutines = deletedSubRoutineSummaries.map {
+            SubRoutineSummaryEntity(
+                subRoutineId: $0.subRoutineId,
+                subRoutineName: nil,
+                sortOrder: nil)
+        }
+        let finalSubRoutines = updatedSubRoutines + deletedSubRoutines
+
+        try await routineRepository.updateRoutine(routineSummary: routineSummary, subRoutineSummaries: finalSubRoutines)
     }
 }

--- a/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
@@ -24,7 +24,7 @@ public final class RoutineUseCase: RoutineUseCaseProtocol {
         let start = startDate.convertToString(dateType: .yearMonthDate)
         let end = endDate.convertToString(dateType: .yearMonthDate)
 
-        var routineEntities = try await routineRepository.fetchRoutines(from: start, to: end)
+        let routineEntities = try await routineRepository.fetchRoutines(from: start, to: end)
         return routineEntities
     }
 
@@ -33,7 +33,7 @@ public final class RoutineUseCase: RoutineUseCaseProtocol {
         subRoutineSummaries: [SubRoutineSummaryEntity],
         deletedSubRoutineSummaries: [SubRoutineSummaryEntity]
     ) async throws {
-        if let routineId = routineSummary.routineId { // 루틴 아이디가 있으면 수정, 없으면 생성
+        if routineSummary.routineId == nil { // 루틴 아이디가 있으면 수정, 없으면 생성
             try await createRoutine(routineSummary: routineSummary, subRoutinesSummaries: subRoutineSummaries)
         } else {
             try await updateRoutine(

--- a/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
+++ b/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
@@ -66,8 +66,11 @@ public struct PresentationDependencyAssembler: DependencyAssemblerProtocol {
             return EmotionRegisterViewModel(emotionUseCase: emotionUseCase)
         }
 
-        DIContainer.shared.register(type: RoutineCreationViewModel.self) { _ in
-            return RoutineCreationViewModel()
+        DIContainer.shared.register(type: RoutineCreationViewModel.self) { container in
+            guard let routineUseCase = container.resolve(type: RoutineUseCaseProtocol.self)
+            else { fatalError("routineUseCase 의존성이 등록되지 않았습니다.") }
+
+            return RoutineCreationViewModel(routineUseCase: routineUseCase)
         }
 
         DIContainer.shared.register(type: ResultRecommendedRoutineViewModel.self) { container in

--- a/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
+++ b/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
@@ -18,13 +18,19 @@ struct MainRoutine {
 }
 
 extension RoutineEntity {
-    func toMainRoutine() -> MainRoutine {
+    func toMainRoutine() -> MainRoutine? {
+        guard let routineId else { return nil }
+
+        let subRoutines = subRoutineSearchResultDto.compactMap { $0.toSubRoutine() }
+        let isAllConverted = subRoutines.count == subRoutineSearchResultDto.count
+        guard isAllConverted else { return nil }
+
         return MainRoutine(
             id: routineId,
             title: routineName,
             isDone: completeYn,
             startTime: Date.convertToDate(from: executionTime, dateType: .time) ?? Date(),
             repeatDay: repeatDay.compactMap({ Week(rawValue: $0) }),
-            subRoutines: subRoutineSearchResultDto.map({ $0.toSubRoutine() }))
+            subRoutines: subRoutines)
     }
 }

--- a/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
+++ b/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
@@ -30,7 +30,7 @@ extension RoutineEntity {
             title: routineName,
             isDone: completeYn,
             startTime: Date.convertToDate(from: executionTime, dateType: .time) ?? Date(),
-            repeatDay: repeatDay.compactMap({ Week(rawValue: $0) }),
+            repeatDay: repeatDay.compactMap({ Week(rawValue: $0.rawValue) }),
             subRoutines: subRoutines)
     }
 }

--- a/Projects/Presentation/Sources/Home/Model/SubRoutine.swift
+++ b/Projects/Presentation/Sources/Home/Model/SubRoutine.swift
@@ -15,7 +15,9 @@ struct SubRoutine: Hashable {
 }
 
 extension SubRoutineEntity {
-    func toSubRoutine() -> SubRoutine {
+    func toSubRoutine() -> SubRoutine? {
+        guard let subRoutineId else { return nil }
+
         return SubRoutine(
             id: subRoutineId,
             title: subRoutineName,

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -529,7 +529,7 @@ extension HomeView: RoutineDetailViewDelegate {
         guard let routineCreationViewModel = DIContainer.shared.resolve(type: RoutineCreationViewModel.self) else {
             fatalError("routineCreationViewModel 의존성이 등록되지 않았습니다.")
         }
-        let routineCreationView = RoutineCreationView(viewModel: routineCreationViewModel)
+        let routineCreationView = RoutineCreationView(viewModel: routineCreationViewModel, routineId: routine.id)
         routineCreationView.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(routineCreationView, animated: true)
     }

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -98,7 +98,7 @@ final class HomeViewModel: ViewModel {
             do {
                 let entities = try await routineUseCase.fetchRoutines(startDate: startDate, endDate: endDate)
                 for (date, routineEntities) in entities {
-                    routines[date] = routineEntities.map({ $0.toMainRoutine() })
+                    routines[date] = routineEntities.compactMap({ $0.toMainRoutine() })
                 }
                 fetchRoutineResultSubject.send(true)
             } catch {

--- a/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationView.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationView.swift
@@ -77,26 +77,30 @@ final class RoutineCreationView: BaseViewController<RoutineCreationViewModel> {
 
     private let registerButton = UIButton()
 
+    private let navigationTitle: String
+    private let registerButtonTitle: String
     private var repeatRoutineTitleTopConstraint: Constraint?
     private var startTimeTitleTopConstraint: Constraint?
 
     private var cancellables = Set<AnyCancellable>()
 
-    override init(viewModel: RoutineCreationViewModel) {
+    init(viewModel: RoutineCreationViewModel, routineId: String? = nil) {
+        navigationTitle = routineId == nil ? "루틴 등록" : "루틴 수정"
+        registerButtonTitle = routineId == nil ? "등록하기" : "수정하기"
+
         super.init(viewModel: viewModel)
+        if let routineId {
+            viewModel.action(input: .fetchRoutine(id: routineId))
+        }
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        configureNavigationBar(navigationStyle: .withBackButton(title: "루틴 등록"))
+        configureNavigationBar(navigationStyle: .withBackButton(title: navigationTitle))
     }
 
     override func configureAttribute() {
@@ -171,7 +175,7 @@ final class RoutineCreationView: BaseViewController<RoutineCreationViewModel> {
 
         registerButton.layer.cornerRadius = 12
         registerButton.layer.masksToBounds = true
-        registerButton.setTitle("등록하기", for: .normal)
+        registerButton.setTitle(registerButtonTitle, for: .normal)
         registerButton.isEnabled = false
         registerButton.titleLabel?.font = BitnagilFont.init(style: .body1, weight: .semiBold).font
     }
@@ -517,6 +521,12 @@ final class RoutineCreationView: BaseViewController<RoutineCreationViewModel> {
                 let datePickerView = DatePickerView()
                 datePickerView.delegate = self
                 self?.presentCustomBottomSheet(contentViewController: datePickerView, maxHeight: Layout.datePickerBottomSheetHeight)
+            },
+            for: .touchUpInside)
+
+        registerButton.addAction(
+            UIAction { [weak self] _ in
+                self?.viewModel.action(input: .registerRoutine)
             },
             for: .touchUpInside)
     }

--- a/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
@@ -4,7 +4,9 @@
 //
 //  Created by 이동현 on 7/20/25.
 //
+
 import Combine
+import Domain
 import Foundation
 
 final class RoutineCreationViewModel: ViewModel {
@@ -38,6 +40,7 @@ final class RoutineCreationViewModel: ViewModel {
     }
 
     enum Input {
+        case fetchRoutine(id: String)
         case configureName(name: String)
         case addSubRoutine
         case deleteSubRoutine(index: Int)
@@ -60,16 +63,23 @@ final class RoutineCreationViewModel: ViewModel {
 
     private(set) var output: Output
     private let nameSubject = CurrentValueSubject<String?, Never>("")
-    private let subRoutinesSubject = CurrentValueSubject<[String], Never>([])
+    private let subRoutinesSubject = CurrentValueSubject<[SubRoutineSummaryEntity], Never>([])
     private let repeatTypeSubject = CurrentValueSubject<RepeatType?, Never>(nil)
     private let weekDaySubject = CurrentValueSubject<Set<Week>, Never>([])
     private let executionTimeSubject = CurrentValueSubject<ExecutionType, Never>(.none)
     private let checkRoutinePublisher = PassthroughSubject<Bool, Never>()
+    private let routineUseCase: RoutineUseCaseProtocol
+    private var deletedSubroutines = Set<SubRoutineSummaryEntity>()
+    private var routineId: String?
 
-    init() {
+    init(routineUseCase: RoutineUseCaseProtocol) {
+        self.routineUseCase = routineUseCase
+
         output = Output(
             namePublisher: nameSubject.eraseToAnyPublisher(),
-            subRoutinesPublisher: subRoutinesSubject.eraseToAnyPublisher(),
+            subRoutinesPublisher: subRoutinesSubject
+                .map { $0.compactMap { $0.subRoutineName } }
+                .eraseToAnyPublisher(),
             repeatTypePublisher: repeatTypeSubject.eraseToAnyPublisher(),
             weekDayPublisher: weekDaySubject.eraseToAnyPublisher(),
             executionTimePublisher: executionTimeSubject
@@ -80,6 +90,8 @@ final class RoutineCreationViewModel: ViewModel {
 
     func action(input: Input) {
         switch input {
+        case .fetchRoutine(let id):
+            fetchRoutine(id: id)
         case .configureName(let name):
             configureName(name: name)
         case .addSubRoutine:
@@ -89,7 +101,7 @@ final class RoutineCreationViewModel: ViewModel {
         case .configureSubRoutine(let name, let index):
             configureSubroutine(name: name, index: index)
         case .configureRepeatType(let type):
-            configureRepeatType(type: type)
+            configureRepeatType(selectedType: type)
         case .toggleRepeatDay(let weekDay):
             configureWeekDay(weekDay: weekDay)
         case .toggleRepeatAllDay:
@@ -103,6 +115,43 @@ final class RoutineCreationViewModel: ViewModel {
         updateIsRoutineValid()
     }
 
+    private func fetchRoutine(id: String) {
+        Task {
+            do {
+                // TODO: - routine fetch 실패 시 처리 방안 필요 (기획과 논의~)
+                guard let routine = try await routineUseCase.fetchRoutine(routineId: id) else { return }
+
+                let subRoutines = routine.subRoutineSearchResultDto.map {
+                    SubRoutineSummaryEntity(
+                        subRoutineId: $0.subRoutineId,
+                        subRoutineName: $0.subRoutineName,
+                        sortOrder: $0.sortOrder)
+                }
+                let weekDay = routine.repeatDay.compactMap { Week(rawValue: $0.rawValue) }
+                let repeatType: RepeatType = weekDay.count == Week.allCases.count ? .daily : .week
+                let executionType: ExecutionType
+
+                if routine.executionTime == "00:00:00" {
+                    executionType = .allDay
+                } else {
+                    let time = Date.convertToDate(from: routine.executionTime, dateType: .amPmTimeShort)
+                    executionType = .time(startAt: time ?? Date())
+                }
+
+                nameSubject.send(routine.routineName)
+                subRoutinesSubject.send(subRoutines)
+                weekDaySubject.send(Set(weekDay))
+                repeatTypeSubject.send(repeatType)
+                executionTimeSubject.send(executionType)
+                routineId = id
+
+                updateIsRoutineValid()
+            } catch {
+                // TODO: - 요기도 마찬가지 (ViewModel 공통 todo)
+            }
+        }
+    }
+
     private func configureName(name: String) {
         nameSubject.send(name)
     }
@@ -111,7 +160,12 @@ final class RoutineCreationViewModel: ViewModel {
         var subRoutines = subRoutinesSubject.value
         guard subRoutines.count <= 3 else { return }
 
-        subRoutines.append("")
+        let newSubRoutine = SubRoutineSummaryEntity(
+            subRoutineId: nil,
+            subRoutineName: "",
+            sortOrder: subRoutines.count + 1)
+
+        subRoutines.append(newSubRoutine)
         subRoutinesSubject.send(subRoutines)
     }
 
@@ -121,6 +175,12 @@ final class RoutineCreationViewModel: ViewModel {
             index >= 0,
             index < subRoutines.count
         else { return }
+
+        let targetSubRoutine = subRoutines[index]
+
+        if targetSubRoutine.subRoutineId != nil {
+            deletedSubroutines.insert(targetSubRoutine)
+        }
 
         subRoutines.remove(at: index)
         subRoutinesSubject.send(subRoutines)
@@ -133,21 +193,29 @@ final class RoutineCreationViewModel: ViewModel {
             index < subRoutines.count
         else { return }
 
-        subRoutines[index] = name
+        let originalSubRoutine = subRoutines[index]
+        let newSubRoutine = SubRoutineSummaryEntity(
+            subRoutineId: originalSubRoutine.subRoutineId,
+            subRoutineName: name,
+            sortOrder: originalSubRoutine.sortOrder)
+        subRoutines[index] = newSubRoutine
+
         subRoutinesSubject.send(subRoutines)
     }
 
-    private func configureRepeatType(type: RepeatType) {
-        var repeatType = repeatTypeSubject.value
+    private func configureRepeatType(selectedType: RepeatType) {
+        let repeatType = repeatTypeSubject.value
 
-        repeatType = repeatType == type
-            ? nil
-            : type
-
-        if repeatType != .week {
-            weekDaySubject.send([])
+        switch selectedType {
+        case .daily:
+            weekDaySubject.send(Set(Week.allCases))
+        case .week:
+            if repeatType == .daily {
+                weekDaySubject.send([])
+            }
         }
-        repeatTypeSubject.send(repeatType)
+
+        repeatTypeSubject.send(selectedType)
     }
 
     private func configureWeekDay(weekDay: Week) {
@@ -178,7 +246,12 @@ final class RoutineCreationViewModel: ViewModel {
         guard
             let name = nameSubject.value,
             !name.isEmpty,
-            executionTimeSubject.value != .none
+            executionTimeSubject.value != .none,
+            weekDaySubject.value.count > 0,
+            subRoutinesSubject
+                .value
+                .map({$0.subRoutineName})
+                .allSatisfy({$0?.isEmpty == false })
         else {
             checkRoutinePublisher.send(false)
             return
@@ -188,6 +261,37 @@ final class RoutineCreationViewModel: ViewModel {
     }
 
     private func registerRoutine() {
-        // API 호출
+        Task {
+            do {
+                let repeatDay = weekDaySubject
+                    .value
+                    .sorted(by: { $0.id < $1.id })
+                    .map { $0.rawValue }
+
+                let executionTime: String
+
+                switch executionTimeSubject.value {
+                case .time(let startAt):
+                    executionTime = startAt.convertToString(dateType: .time)
+                case .allDay:
+                    executionTime = "00:00:00"
+                case .none:
+                    return
+                }
+
+                let routineSummary = RoutineSummaryEntity(
+                    routineId: routineId,
+                    routineName: nameSubject.value ?? "",
+                    repeatDay: repeatDay,
+                    executionTime: executionTime)
+
+                try await routineUseCase.saveRoutine(
+                    routineSummary: routineSummary,
+                    subRoutineSummaries: subRoutinesSubject.value,
+                    deletedSubRoutineSummaries: Array(deletedSubroutines))
+            } catch {
+
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 루틴 등록, 수정 로직 구현 및 API 연결
- UI 변경 사항 없음!

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 루틴 등록/수정에서 사용할 Entity 정의 (리뷰 노트를 확인해주세요!!)
- 루틴 수정 로직 구현
- 루틴 등록, 수정 API 정의 및 연결

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
개발 지능이 많이 하락했구나~ 라는 것을 느낄 수 있었던 PR입니다. 그 이유는 다름 아닌 작업 순서 때문인데요, 지금도 왜 그랬는지 모르겠는데, DataSource 레이어쪽 작업을 먼저 진행했습니다. 때문에 이후 Domain 쪽 작업을 진행하며 Domain에서 약간의 구조 변경이 생김에 따라 DataSource를 다시 수정하게 되는 등 일을 두 번 하게 되었습니다. 반성하면서 다시 개발 지능을 쌓아가기로 다짐하며,, 본격적으로 약식 PR 설명회(라 쓰고 진짜 고봉밥 ㅠ)를 진행하겠습니다~


### 루틴 등록 / 수정하기
<img width="2496" height="1440" alt="image" src="https://github.com/user-attachments/assets/9d8a3218-62ec-4c6e-8f0d-e131997bea23" />
- 루틴등록(수정) 화면에서 루틴을 모두 작성한 이후, `RoutineUseCase`의 `saveRoutine`을 통해 루틴을 저장할 수 있도록 구현했습니다.
- 신규 루틴인지, 기존 루틴인지 판단하는 기준은 루틴의 ID 값이 있느냐 없느냐입니다. 해당 값을 기준으로 useCase 안에서 분기처를 통해 각각 루틴 등록/루틴 수정을 실행하도록 구현했습니다. 정리하자면 Presentation 단에서는 루틴 수정인지, 등록인지 상관쓰지 않고 일관적으로 동작할 수 있도록 구현하고자 했습니다.


### 고민했던 부분들 
#### 1. 루틴 등록(createRoutine), 루틴 수정(updateRoutine)을 View에서는 루틴 저장(saveRoutine) 하나로 동작하게 하는 것이 의미 있는가?
- 아시다시피, 등록과 수정은 API가 다릅니다. 그리고 `body`에 넘겨줘야 하는 `parameter`의 형식도 다릅니다. 수정같은 경우는 각 루틴과 서브루틴의 ID값을 같이 넘겨주어야 하고, 서브루틴의 경우 `sortOrder`를 또 넘겨줘야 합니다.
- 그리고 위에서 말씀드린대로, Presentation은 루틴 `Usecase`를 사용할 때, 수정요청인지, 등록 요청인지 구분하지 않고 '루틴 저장' 이라는 메서드 하나만 바라보고 동작하게 했습니다. 왜 이렇게 했냐면!!! `Presentation` 레이어에서 '등록', 그리고 '수정' 에 따른 분기처리를 하는 것 보다, `Domain`에서 등록/수정 여부를 판단하고 분기처리하는 것이 `Presentation`쪽을 더 멍청하게 만들기 좋다 생각했기 때문입니다.
- 하지만.. 이게 그렇게 의미가 있나 싶기도 합니다. `Presentation` 측에서 분기처리를 통해 대단한 로직을 실행하는 것도 아니고, 분기처리도 단순히 routine에 id가 있냐 없냐로 처리할 수 있거든요
- 그리고 View쪽에서 아예 분기처리를 하지 않는것도 아닙니다. navigation 바에 제목을 표시하기 위해 분기처리를 한 번하고 있거든요 ㅎㅎ.. 그래서 이렇게 구현한게 의미가 있을까 하는 고민이 들었습니다~

#### 2. Entity를 어떻게 정의 해야할까~
- 클린 아키텍쳐의 핵심은 잘 아시다시피, 의존성의 방향이 안쪽으로만 흐른다는 것입니다. 다시 말해 중앙에 있는 Domain이 중심을 잡고, Domain 외부의 layer가 Domain에 의존성이 있는 구조가 되는 것이죠. 처음에 구조를 나름 잘 잡아서, 전체 구조를 보면 의존성 역전을 통해 의존성이 안쪽 한 방향으로만 흐르게 구현이 되어있다 생각합니다.

- 한편, 루틴등록/수정을 구현하기 위해 `RoutineSummaryEntity`와 `SubRoutineSummaryEntity`를 구현했는데요, 각 구조체들은 아래와 같이 생겼습니다.

```swift
public struct RoutineSummaryEntity {
    public let routineId: String?
    public let routineName: String
    public let repeatDay: [WeekType]
    public let executionTime: String

    public init(
        routineId: String?,
        routineName: String,
        repeatDay: [String]?,
        executionTime: String
    ) {
        let weekType: [WeekType] = repeatDay?.compactMap(WeekType.init(rawValue:)) ?? []

        self.routineId = routineId
        self.routineName = routineName
        self.repeatDay = weekType
        self.executionTime = executionTime
    }
}

public struct SubRoutineSummaryEntity: Decodable, Hashable {
    public let subRoutineId: String?
    public let subRoutineName: String?
    public let sortOrder: Int?

    public init(
        subRoutineId: String?,
        subRoutineName: String?,
        sortOrder: Int?
    ) {
        self.subRoutineId = subRoutineId
        self.subRoutineName = subRoutineName
        self.sortOrder = sortOrder
    }
}
```
뭔가 이상하다는 생각이 드셨다면, 맞습니다 ㅠ 거의 이후 데이터 요청을 위해 변환될 DTO의 구조와 동일합니다. 아래는 DTO의 구조입니다.

```swift
struct RoutineUpdateDTO: Codable {
    let routineId: String
    let routineName: String
    let repeatDay: [String]
    let executionTime: String
    let subRoutineInfos: [SubRoutineUpdateDTO]
}

struct SubRoutineUpdateDTO: Codable {
    let subRoutineId: String?
    let subRoutineName: String?
    let sortOrder: Int?
}
```

- 이렇게 `SummaryEntity`를 구현하며 쉽게 API를 연결할 수는 잇엇지만,, 그리고 구조만 따져봤을때는 `Domain`이 `DataSource`를 `import` 하지 않으므로 의존성 방향을 잘 지키는 것처럼 보이지만,, 직접 구현한 저는 알고 있습니다 ㅠ 이 Entity는 직접적으로 `DataSource`를 모르는 것일 뿐, 서버에서 내려주는 response와 요구하는 request에 엄청나게 의존하고 있다는 것을요..,.,., 다시 말해 DTO의 변경에 따라 이 Entity의 구조도 바뀔 가능성이 높다는 것이죠 (굉장히 잘못된 구조)

- 원래 계획은, 루틴 등록, 수정 시에 `UseCase`에서는 `RoutineEntity`를 들고 있고, `Repository` 쪽에서 `RoutineEntity` 안에서 필요한 정보만 뽑아 쓸 수 있도록 하는 것을 생각했습니다. 하지만 `RoutineEntity`에 생각보다 등록/수정 시에 사용하지 않는 정보가 많이 있었고, 아래 두 가지 방법을 고려했습니다.
    1. `RoutineEntity` 에서 등록/수정에서 사용하지 않는 프로퍼티는 옵셔널로 변경하기
    2. 등록/수정에서 사용하지 않는 프로퍼티는 기본값을 넣어주기 (String에는 "", Int에는 0 등)

- 1번 방법은 제가 구현하지 않는 부분에 대해서 많은 변경을 해야한다는 점에서, 말씀드리지 않고 진행하는 것은 문제가 있다 생각해서 진행하지 못했습니다. 또한 이 방법대로 진행하면, `RoutineEntity`의 대부분의 프로퍼티가 옵셔널 상수가 된다는 점에서 적절한 방법이 아니라 생각했습니다. (엔티티의 거의 모든 프로퍼티가 옵셔널이라면, 차라리 엔티티의 프로퍼티를 쪼개는 것이 낫지 않나 하는 생각했습니다. 비유하자면 엔티티의 프로퍼티도 역할 분리를 하듯 더 작은 단위로 쪼개는 것이죠)
- 2번 방법은 직관적으로도 지양하고 싶은 방법이라 느꼈습니다. 다른 사람이 유지보수를 위해 코드를 봤는데, 임의로 기본 값을 넣어주는 코드를 보면 왜  이 값을 넣어줘야 하는지 파악하기 힘들 것입니다. 또한 어떤 경우에는 기본 값을 넣어주고, 어떤 경우에는 넣지 않아야 하는지 파악하기 힘들 것이라 생각했습니다.

- 결론을 말씀드리자면, 엔티티를 한 번 같이 정리하고, 정의하면 좋을 것 같다는 생각이 들었습니다. 서버도 V2로 리팩토링이 예정된 만큼, 엔티티를 확실하게 정의하고 넘어가야 추후 외부의 변경에도 Domain의 변경을 최소화할 수 있을 것이라 생각하기 떄문입니다!

### 논의해보고 싶은 부분들
드디어.. Domain레이어를 처음 건드려 본 만큼, 구현하면서 논의해보면 좋겠다~ 하는 부분들이 있었습니다.
물론 아래서 드리는 말씀이 현재 방법이 틀렸다는 것은 절대 아니고, 가볍게 나눠보면 좋겠다~ 라고 들어주시면 감사하겠습니다 🙇‍♂️🙇‍♂️🙇‍♂️

#### 1. View의 네이밍
- 현재는 ViewController의 이름도 View라고 명명되어 있습니다. 화면, 즉 View를 의미하기 때문인 것으로 기억하는데요, 조심스럽게.. ViewController라는 풀 네임은 어떤지 의견을 내봅니다. 이유는 아래와 같습니다
    1. 많은 iOS 개발자 분들이 이름 축약을 지양
    2. VC 역시 View는 맞지만, binding, 화면 전환 등 UIView 의 서브 클래스보다 하는 일이 많음
    3. 사실은 가장 큰 이유인데요.. 관성적인 부분이긴 하지만, 뒤에 ViewController가 붙어 있어야 필요한 파일을 찾을 때 더 빠르게 눈에 들어와서 찾을 수 있다고 느껴집니다
- 1번 이유같은 경우는 물론 지금도 완전 축약형 이름은 아니긴 하지만, ViewController 서브클래스를 View로 명명했다는 점에서 약간의 축약이 들어갔다 볼 수 있지 않을까 했습니다!


#### 2. Repository의 역할
- 현재 DTO 객체에서 Entity로의 변환을 하고 있습니다. DataSource가 Domain을 알고 있는 것은 자연스럽기 때문에 문제가 되는 구조는 아니지만, 해당 책임을 Repository로 옮기는 것은 어떻게 생각하실까요?
- 현재 구조는 DTO의 구조를 파악하면서 Entity로의 변환 과정을 한눈에 볼 수 있어 가독성에서는 장점이 있다 생각합니다. 다만 위와같은 의견을 드리는 이유는, 역할 분리 (관심사 분리) 측면에서는 Repository나, Mapper 객체가 데이터 간 매핑 책임을 가져가는게 유리하다고 생각하기 때문입니다.
- 또한 현재 Bitnagil의 API가 대부분 그렇지 않지만, 일부 경우에는 Entity 에서 DTO의 매핑이 필요한 경우가 있습니다. DTO -> Entity의 매핑은 DTO객체에서 진행할 수 있지만, `Entity -> DTO의 매핑`은 Entity가 DTO를 알 수 없기 때문에 DataSource layer에서 이뤄져야 합니다. 아마 이 과정은 Repository에서 일어나게 될 텐데요, Repository에서 Entity -> DTO의 매핑 책임을 가져간다면 반대의 경우도 repository가 가져가는 것이 조금 더 일관성 있을 것이라고 생각했습니다 
- 마지막으로, Domain과 DataSource 레이어가 만나는 접점이 Repository입니다. Domain은 Repository 프로토콜(추상체)만 알며, DataSource는 이 프로토콜을 채택해 실제 구현을 담당합니다. 그래서 `DTO <-> Entity 변환`도 이 접점(Repository)에서 이뤄지는 것이 적절하다고 생각했습니다.
- 물론, 데이터 매핑 책임을 repository가 가져간다면, 일부 경우에서 데이터 매핑 로직 때문에 가독성이 떨어질 수 있습니다. 복잡하게 매핑을 해야 하는 경우가 많아질 수록 더욱 그럴 것입니다. 그런 경우가 생긴다면, 사실 데이터 매핑을 어디서 해주든 가독성이 떨어지는 것은 마찬가지 일 것이라 생가갛비낟. 따라서 해당 문제가 발생하면 데이터를 매핑해주는 Mapper 객체의 도입을 고려보면 좋을 것 같습니다.

위 두 가지 안건의 경우, 꼭 당장 정하거나 수정할 부분은 아니기 때문에 시간이 정말로 부족한 지금은 살짝 넘어가고 나중에 다시 이야기 해봐도 좋을 것 같습니다! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 루틴 생성, 조회, 수정 기능이 추가되었습니다.
  * 루틴 및 서브루틴 정보를 담는 다양한 엔터티와 DTO가 도입되었습니다.
  * 요일 선택을 위한 열거형(WeekType)이 추가되었습니다.

* **기능 개선**
  * 루틴 및 서브루틴 ID, 반복 요일 등 데이터 구조가 개선되어 더 유연한 관리가 가능합니다.
  * 루틴 생성/수정 화면에서 기존 루틴 불러오기 및 수정이 지원됩니다.
  * 루틴 생성/수정 시 유효성 검사가 강화되었습니다.

* **버그 수정**
  * 루틴 및 서브루틴 변환 과정에서 ID 누락 시 오류를 방지하도록 처리되었습니다.

* **리팩터링/구조 개선**
  * 도메인 및 데이터 계층의 구조가 확장되어, 유지보수성과 확장성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->