### PR TITLE
[Feat] 네트워킹 로깅 플러그인 구현

### DIFF
--- a/Projects/DataSource/Sources/NetworkService/NetworkService.swift
+++ b/Projects/DataSource/Sources/NetworkService/NetworkService.swift
@@ -18,7 +18,8 @@ final class NetworkService {
         plugins = [
             TokenInjectionPlugin(),
             RefreshTokenPlugin(),
-            RetryPlugin()]
+            RetryPlugin(),
+            BitnagilLoggingPlugin()]
     }
 
     func request<T: Decodable>(
@@ -61,11 +62,6 @@ final class NetworkService {
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
-        // TODO: - 로깅 로직 수정
-        if let httpResponse = response as? HTTPURLResponse {
-            BitnagilLogger.log(logType: .info, message: "응답 코드: \(httpResponse.statusCode)")
-        }
-
         if withPlugins {
             for plugin in plugins {
                 try await plugin.didReceive(
@@ -79,19 +75,15 @@ final class NetworkService {
         else { throw NetworkError.invalidResponse }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            BitnagilLogger.log(logType: .error, message: "응답 코드: \(httpResponse.statusCode)")
             throw NetworkError.invalidStatusCode(statusCode: httpResponse.statusCode)
         }
 
-        guard !data.isEmpty
-        else { throw NetworkError.emptyData }
+        guard !data.isEmpty else { throw NetworkError.emptyData }
 
         do {
             let baseResponse = try decoder.decode(BaseResponse<T>.self, from: data)
-            BitnagilLogger.log(logType: .info, message: "Server Message: \(baseResponse.message)")
 
-            guard let responseDTO = baseResponse.data
-            else { return nil }
+            guard let responseDTO = baseResponse.data else { return nil }
 
             return responseDTO
         } catch {

--- a/Projects/DataSource/Sources/NetworkService/Plugin/BitnagilLoggingPlugin.swift
+++ b/Projects/DataSource/Sources/NetworkService/Plugin/BitnagilLoggingPlugin.swift
@@ -1,0 +1,70 @@
+//
+//  BitnagilLoggingPlugin.swift
+//  DataSource
+//
+//  Created by 이동현 on 8/3/25.
+//
+
+import Foundation
+import Shared
+
+
+struct BitnagilLoggingPlugin: NetworkPlugin {
+    func willSend(request: URLRequest, endpoint: Endpoint) async throws -> URLRequest {
+        let urlString = request.url?.absoluteString ?? ""
+        let method = request.httpMethod ?? ""
+        let headers = request.allHTTPHeaderFields ?? [:]
+        let body: String
+        if let bodyData = request.httpBody {
+            body = String(data: bodyData, encoding: .utf8) ?? "디코딩 실패"
+        } else {
+            body = "내용 없음"
+        }
+
+        BitnagilLogger.log(
+            logType: .debug,
+            message: """
+                    REQUEST➡️
+                    - URL: \(urlString)
+                    - Method: \(method)
+                    - Headers: \(headers)
+                    - Body: \(body)
+                    """
+        )
+        return request
+    }
+
+    func didReceive(response: URLResponse, data: Data?, endpoint: Endpoint) async throws {
+        let urlString = response.url?.absoluteString ?? ""
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            BitnagilLogger.log(logType: .error, message: "🚨\(urlString)에 대한 response는 HTTPResponse가 아닙니다.🚨")
+            return
+        }
+
+        let statusCode = httpResponse.statusCode
+        let headers = httpResponse.allHeaderFields
+
+        // code/message 추출
+        var code: String = ""
+        var message: String = ""
+        if
+            let data = data,
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        {
+            code = json["code"] as? String ?? ""
+            message = json["message"] as? String ?? ""
+        }
+
+        BitnagilLogger.log(
+            logType: .debug,
+            message: """
+                RESPONSE⬅️
+                - 요청URL: \(urlString)
+                - Status: \(statusCode)
+                - Code: \(code)
+                - Message: \(message)
+                """
+        )
+    }
+}

--- a/Projects/DataSource/Sources/NetworkService/Plugin/BitnagilLoggingPlugin.swift
+++ b/Projects/DataSource/Sources/NetworkService/Plugin/BitnagilLoggingPlugin.swift
@@ -8,7 +8,6 @@
 import Foundation
 import Shared
 
-
 struct BitnagilLoggingPlugin: NetworkPlugin {
     func willSend(request: URLRequest, endpoint: Endpoint) async throws -> URLRequest {
         let urlString = request.url?.absoluteString ?? ""
@@ -43,7 +42,6 @@ struct BitnagilLoggingPlugin: NetworkPlugin {
         }
 
         let statusCode = httpResponse.statusCode
-        let headers = httpResponse.allHeaderFields
 
         // code/message 추출
         var code: String = ""


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 이전 https://github.com/YAPP-Github/Bitnagil-iOS/pull/30 에서 로깅 로직을 꼬아버린 바람에 네트워크 요청/응답을 확인하는데 어려움이 있었습니다.
- 때문에 플러그인을 통해 요청/응답 값을 확인해볼 수 있도록 구현했습니다.
- 다만 response body의 경우, 값이 너무 길어지는 경우가 있었습니다. 오히려 가독성이 떨어진다고 느껴져서 server에서 보내는 code와 message 값만 콘솔에 찍도록 구현했습니다

## 📱 Screenshot
<img width="819" height="341" alt="image" src="https://github.com/user-attachments/assets/c6f2cd45-7d02-4d45-bc58-f78a9067031a" />
- request는 헤더를 찍기 때문에 토큰 값이 포함되어 있어 사진 첨부하지 않았습니다. (어차피 만료된 토큰이지만 그래도 올리지 않기로 함~!)


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 네트워크 로깅 플러그인 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 네트워크 요청 및 응답에 대한 상세 로그를 제공하는 BitnagilLoggingPlugin이 추가되었습니다.

* **리팩터링**
  * 기존 네트워크 서비스의 수동 로그 코드가 제거되고, 로그 처리가 플러그인으로 위임되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->