### PR TITLE
[Feat-T3-134] 루틴 삭제 구현

### DIFF
--- a/Projects/DataSource/Sources/DTO/DeleteRoutineDTO.swift
+++ b/Projects/DataSource/Sources/DTO/DeleteRoutineDTO.swift
@@ -1,0 +1,19 @@
+//
+//  DeleteRoutineDTO.swift
+//  DataSource
+//
+//  Created by 최정인 on 8/4/25.
+//
+
+struct DeleteRoutineDTO: Encodable {
+    let routineId: String
+    let routineCompletionId: Int?
+    let historySeq: Int
+    let performedDate: String
+    let subRoutineInfosForDelete: [DeleteSubRoutineDTO]
+}
+
+struct DeleteSubRoutineDTO: Encodable {
+    let subRoutineId: String
+    let routineCompletionId: Int?
+}

--- a/Projects/DataSource/Sources/DTO/DeleteRoutineDTO.swift
+++ b/Projects/DataSource/Sources/DTO/DeleteRoutineDTO.swift
@@ -9,6 +9,7 @@ struct DeleteRoutineDTO: Encodable {
     let routineId: String
     let routineCompletionId: Int?
     let historySeq: Int
+    let routineType: String
     let performedDate: String
     let subRoutineInfosForDelete: [DeleteSubRoutineDTO]
 }

--- a/Projects/DataSource/Sources/Endpoint/EmotionEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/EmotionEndpoint.swift
@@ -22,7 +22,7 @@ extension EmotionEndpoint: Endpoint {
             return baseURL
         case .fetchEmotion(let date):
             return baseURL + "/\(date)"
-        case .registerEmotion(let emotion):
+        case .registerEmotion:
             return baseURL
         }
     }

--- a/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
@@ -11,6 +11,7 @@ enum RoutineEndpoint {
     case fetchRoutines(startDate: String, endDate: String)
     case updateRoutine(routine: RoutineUpdateDTO)
     case deleteAllRoutine(routineId: String)
+    case deleteDailyRoutine(routine: DeleteRoutineDTO)
 }
 
 extension RoutineEndpoint: Endpoint {
@@ -24,6 +25,8 @@ extension RoutineEndpoint: Endpoint {
             "\(baseURL)/\(routineId)"
         case .deleteAllRoutine(let routineId):
             "\(baseURL)/\(routineId)"
+        case .deleteDailyRoutine:
+            "\(baseURL)/day"
         default:
             baseURL
         }
@@ -37,7 +40,7 @@ extension RoutineEndpoint: Endpoint {
                 .get
         case .updateRoutine:
                 .patch
-        case .deleteAllRoutine:
+        case .deleteAllRoutine, .deleteDailyRoutine:
                 .delete
         }
     }
@@ -66,6 +69,8 @@ extension RoutineEndpoint: Endpoint {
         case .createRoutine(let routine):
             return routine.dictionary
         case .updateRoutine(let routine):
+            return routine.dictionary
+        case .deleteDailyRoutine(let routine):
             return routine.dictionary
         default:
             return [:]

--- a/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
@@ -10,6 +10,7 @@ enum RoutineEndpoint {
     case fetchRoutine(routineId: String)
     case fetchRoutines(startDate: String, endDate: String)
     case updateRoutine(routine: RoutineUpdateDTO)
+    case deleteAllRoutine(routineId: String)
 }
 
 extension RoutineEndpoint: Endpoint {
@@ -20,6 +21,8 @@ extension RoutineEndpoint: Endpoint {
     var path: String {
         switch self {
         case .fetchRoutine(let routineId):
+            "\(baseURL)/\(routineId)"
+        case .deleteAllRoutine(let routineId):
             "\(baseURL)/\(routineId)"
         default:
             baseURL
@@ -34,6 +37,8 @@ extension RoutineEndpoint: Endpoint {
                 .get
         case .updateRoutine:
                 .patch
+        case .deleteAllRoutine:
+                .delete
         }
     }
     

--- a/Projects/DataSource/Sources/Repository/RoutineRepository.swift
+++ b/Projects/DataSource/Sources/Repository/RoutineRepository.swift
@@ -62,4 +62,9 @@ final class RoutineRepository: RoutineRepositoryProtocol {
 
         _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
     }
+
+    func deleteAllRoutine(routineId: String) async throws {
+        let endpoint = RoutineEndpoint.deleteAllRoutine(routineId: routineId)
+        _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
+    }
 }

--- a/Projects/DataSource/Sources/Repository/RoutineRepository.swift
+++ b/Projects/DataSource/Sources/Repository/RoutineRepository.swift
@@ -67,4 +67,20 @@ final class RoutineRepository: RoutineRepositoryProtocol {
         let endpoint = RoutineEndpoint.deleteAllRoutine(routineId: routineId)
         _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
     }
+
+    func deleteDailyRoutine(routine: DeleteRoutineEntity) async throws {
+        let deleteSubRoutineDTO = routine
+            .subRoutineInfosForDelete
+            .map({ DeleteSubRoutineDTO(subRoutineId: $0.subRoutineId, routineCompletionId: $0.routineCompletionId) })
+
+        let deleteRoutineDTO = DeleteRoutineDTO(
+            routineId: routine.routineId,
+            routineCompletionId: routine.routineCompletionId,
+            historySeq: routine.historySeq,
+            performedDate: routine.performedDate,
+            subRoutineInfosForDelete: deleteSubRoutineDTO)
+
+        let endpoint = RoutineEndpoint.deleteDailyRoutine(routine: deleteRoutineDTO)
+        _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
+    }
 }

--- a/Projects/DataSource/Sources/Repository/RoutineRepository.swift
+++ b/Projects/DataSource/Sources/Repository/RoutineRepository.swift
@@ -77,6 +77,7 @@ final class RoutineRepository: RoutineRepositoryProtocol {
             routineId: routine.routineId,
             routineCompletionId: routine.routineCompletionId,
             historySeq: routine.historySeq,
+            routineType: routine.routineType,
             performedDate: routine.performedDate,
             subRoutineInfosForDelete: deleteSubRoutineDTO)
 

--- a/Projects/Domain/Sources/Entity/DeleteRoutineEntity.swift
+++ b/Projects/Domain/Sources/Entity/DeleteRoutineEntity.swift
@@ -1,0 +1,38 @@
+//
+//  DeleteRoutineEntity.swift
+//  Domain
+//
+//  Created by 최정인 on 8/4/25.
+//
+
+public struct DeleteRoutineEntity: Encodable {
+    public let routineId: String
+    public let routineCompletionId: Int?
+    public let historySeq: Int
+    public let performedDate: String
+    public let subRoutineInfosForDelete: [DeleteSubRoutineEntity]
+
+    public init(
+        routineId: String,
+        routineCompletionId: Int?,
+        historySeq: Int,
+        performedDate: String,
+        subRoutineInfosForDelete: [DeleteSubRoutineEntity]
+    ) {
+        self.routineId = routineId
+        self.routineCompletionId = routineCompletionId
+        self.historySeq = historySeq
+        self.performedDate = performedDate
+        self.subRoutineInfosForDelete = subRoutineInfosForDelete
+    }
+}
+
+public struct DeleteSubRoutineEntity: Encodable {
+    public let subRoutineId: String
+    public let routineCompletionId: Int?
+
+    public init(subRoutineId: String, routineCompletionId: Int?) {
+        self.subRoutineId = subRoutineId
+        self.routineCompletionId = routineCompletionId
+    }
+}

--- a/Projects/Domain/Sources/Entity/DeleteRoutineEntity.swift
+++ b/Projects/Domain/Sources/Entity/DeleteRoutineEntity.swift
@@ -10,6 +10,7 @@ public struct DeleteRoutineEntity: Encodable {
     public let routineCompletionId: Int?
     public let historySeq: Int
     public let performedDate: String
+    public let routineType: String
     public let subRoutineInfosForDelete: [DeleteSubRoutineEntity]
 
     public init(
@@ -17,12 +18,14 @@ public struct DeleteRoutineEntity: Encodable {
         routineCompletionId: Int?,
         historySeq: Int,
         performedDate: String,
+        routineType: String,
         subRoutineInfosForDelete: [DeleteSubRoutineEntity]
     ) {
         self.routineId = routineId
         self.routineCompletionId = routineCompletionId
         self.historySeq = historySeq
         self.performedDate = performedDate
+        self.routineType = routineType
         self.subRoutineInfosForDelete = subRoutineInfosForDelete
     }
 }

--- a/Projects/Domain/Sources/Entity/Untitled.swift
+++ b/Projects/Domain/Sources/Entity/Untitled.swift
@@ -1,7 +1,0 @@
-//
-//  Untitled.swift
-//  Domain
-//
-//  Created by 이동현 on 8/3/25.
-//
-

--- a/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
@@ -33,4 +33,8 @@ public protocol RoutineRepositoryProtocol {
     /// 반복되는 루틴을 모두 제거합니다.
     /// - Parameter routineId: 삭제할 루틴 id
     func deleteAllRoutine(routineId: String) async throws
+
+    /// 당일 루틴을 삭제합니다.
+    /// - Parameter routine: 삭제할 루틴 정보
+    func deleteDailyRoutine(routine: DeleteRoutineEntity) async throws
 }

--- a/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
@@ -24,10 +24,13 @@ public protocol RoutineRepositoryProtocol {
     ///   - endDate: 조회 종료 날짜
     func fetchRoutines(from startDate: String, to endDate: String) async throws -> [String: [RoutineEntity]]
 
-
     /// 루틴을 수정합니다.
     /// - Parameters:
     ///   - routineSummary: 루틴 요약 정보
     ///   - subRoutineSummaries: 서브 루틴 요약 정보 배열
     func updateRoutine(routineSummary: RoutineSummaryEntity, subRoutineSummaries: [SubRoutineSummaryEntity]) async throws
+
+    /// 반복되는 루틴을 모두 제거합니다.
+    /// - Parameter routineId: 삭제할 루틴 id
+    func deleteAllRoutine(routineId: String) async throws
 }

--- a/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
@@ -19,4 +19,6 @@ public protocol RoutineUseCaseProtocol {
     ) async throws
 
     func deleteAllRoutine(routineId: String) async throws
+
+    func deleteDailyRoutine(routine: DeleteRoutineEntity) async throws
 }

--- a/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
@@ -17,4 +17,6 @@ public protocol RoutineUseCaseProtocol {
         subRoutineSummaries: [SubRoutineSummaryEntity],
         deletedSubRoutineSummaries: [SubRoutineSummaryEntity]
     ) async throws
+
+    func deleteAllRoutine(routineId: String) async throws
 }

--- a/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
@@ -74,4 +74,8 @@ public final class RoutineUseCase: RoutineUseCaseProtocol {
     public func deleteAllRoutine(routineId: String) async throws {
         try await routineRepository.deleteAllRoutine(routineId: routineId)
     }
+
+    public func deleteDailyRoutine(routine: DeleteRoutineEntity) async throws {
+        try await routineRepository.deleteDailyRoutine(routine: routine)
+    }
 }

--- a/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
@@ -70,4 +70,8 @@ public final class RoutineUseCase: RoutineUseCaseProtocol {
 
         try await routineRepository.updateRoutine(routineSummary: routineSummary, subRoutineSummaries: finalSubRoutines)
     }
+
+    public func deleteAllRoutine(routineId: String) async throws {
+        try await routineRepository.deleteAllRoutine(routineId: routineId)
+    }
 }

--- a/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
+++ b/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
@@ -15,6 +15,8 @@ struct MainRoutine {
     let startTime: Date
     let repeatDay: [Week]
     var subRoutines: [SubRoutine]
+    let historySeq: Int
+    let completionId: Int?
 }
 
 extension RoutineEntity {
@@ -31,6 +33,8 @@ extension RoutineEntity {
             isDone: completeYn,
             startTime: Date.convertToDate(from: executionTime, dateType: .time) ?? Date(),
             repeatDay: repeatDay.compactMap({ Week(rawValue: $0.rawValue) }),
-            subRoutines: subRoutines)
+            subRoutines: subRoutines,
+            historySeq: historySeq,
+            completionId: routineCompletionId)
     }
 }

--- a/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
+++ b/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
@@ -17,6 +17,7 @@ struct MainRoutine {
     var subRoutines: [SubRoutine]
     let historySeq: Int
     let completionId: Int?
+    let routineType: String
 }
 
 extension RoutineEntity {
@@ -35,6 +36,7 @@ extension RoutineEntity {
             repeatDay: repeatDay.compactMap({ Week(rawValue: $0.rawValue) }),
             subRoutines: subRoutines,
             historySeq: historySeq,
-            completionId: routineCompletionId)
+            completionId: routineCompletionId,
+            routineType: routineType)
     }
 }

--- a/Projects/Presentation/Sources/Home/Model/SubRoutine.swift
+++ b/Projects/Presentation/Sources/Home/Model/SubRoutine.swift
@@ -12,6 +12,7 @@ struct SubRoutine: Hashable {
     let title: String
     var isDone: Bool
     let sortIndex: Int
+    let completionId: Int?
 }
 
 extension SubRoutineEntity {
@@ -22,6 +23,7 @@ extension SubRoutineEntity {
             id: subRoutineId,
             title: subRoutineName,
             isDone: completeYn,
-            sortIndex: sortOrder)
+            sortIndex: sortOrder,
+            completionId: routineCompletionId)
     }
 }

--- a/Projects/Presentation/Sources/Home/View/Component/RoutineDeleteAlertView.swift
+++ b/Projects/Presentation/Sources/Home/View/Component/RoutineDeleteAlertView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol RoutineDeleteAlertViewDelegate: AnyObject {
     func routineDeleteAlertViewDidTapDeleteAllRoutine(_ sender: RoutineDeleteAlertView)
-    func routineDeleteAlertViewDidTapDeleteDailiyRoutine(_ sender: RoutineDeleteAlertView)
+    func routineDeleteAlertViewDidTapDeleteDailyRoutine(_ sender: RoutineDeleteAlertView)
 }
 
 final class RoutineDeleteAlertView: UIView {
@@ -61,10 +61,12 @@ final class RoutineDeleteAlertView: UIView {
         deleteDailyRoutineButtonConfiguration.background.strokeColor = BitnagilColor.navy500
         deleteDailyRoutineButtonConfiguration.background.strokeWidth = 1
         deleteDailyRoutineButton.configuration = deleteDailyRoutineButtonConfiguration
-        deleteDailyRoutineButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            self.delegate?.routineDeleteAlertViewDidTapDeleteDailiyRoutine(self)
-        }, for: .touchUpInside)
+        deleteDailyRoutineButton.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                self.delegate?.routineDeleteAlertViewDidTapDeleteDailyRoutine(self)
+            },
+            for: .touchUpInside)
 
         var deleteAllRoutineButtonConfiguration = UIButton.Configuration.filled()
         deleteAllRoutineButtonConfiguration.baseBackgroundColor = .white
@@ -76,10 +78,12 @@ final class RoutineDeleteAlertView: UIView {
         deleteAllRoutineButtonConfiguration.background.strokeColor = BitnagilColor.navy500
         deleteAllRoutineButtonConfiguration.background.strokeWidth = 1
         deleteAllRoutineButton.configuration = deleteAllRoutineButtonConfiguration
-        deleteAllRoutineButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            self.delegate?.routineDeleteAlertViewDidTapDeleteAllRoutine(self)
-        }, for: .touchUpInside)
+        deleteAllRoutineButton.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                self.delegate?.routineDeleteAlertViewDidTapDeleteAllRoutine(self)
+            },
+            for: .touchUpInside)
     }
 
     private func configureLayout() {

--- a/Projects/Presentation/Sources/Home/View/Component/RoutineDeleteAlertView.swift
+++ b/Projects/Presentation/Sources/Home/View/Component/RoutineDeleteAlertView.swift
@@ -16,7 +16,12 @@ protocol RoutineDeleteAlertViewDelegate: AnyObject {
 final class RoutineDeleteAlertView: UIView {
 
     private enum Layout {
-
+        static let deleteLabelHeight: CGFloat = 48
+        static let deleteLabelTopSpacing: CGFloat = 23
+        static let buttonHorizontalMargin: CGFloat = 23
+        static let buttonHeight: CGFloat = 44
+        static let deleteDailyRoutineButtonTopSpacing: CGFloat = 22
+        static let deleteAllRoutineButtonTopSpacing: CGFloat = 10
     }
 
     private let contentView = UIView()
@@ -89,23 +94,23 @@ final class RoutineDeleteAlertView: UIView {
         }
 
         deleteLabel.snp.makeConstraints { make in
-            make.height.equalTo(48)
+            make.height.equalTo(Layout.deleteLabelHeight)
             make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(23)
+            make.top.equalToSuperview().offset(Layout.deleteLabelTopSpacing)
         }
 
         deleteDailyRoutineButton.snp.makeConstraints { make in
-            make.top.equalTo(deleteLabel.snp.bottom).offset(22)
-            make.leading.equalToSuperview().offset(23)
-            make.trailing.equalToSuperview().inset(23)
-            make.height.equalTo(44)
+            make.top.equalTo(deleteLabel.snp.bottom).offset(Layout.deleteDailyRoutineButtonTopSpacing)
+            make.leading.equalToSuperview().offset(Layout.buttonHorizontalMargin)
+            make.trailing.equalToSuperview().inset(Layout.buttonHorizontalMargin)
+            make.height.equalTo(Layout.buttonHeight)
         }
 
         deleteAllRoutineButton.snp.makeConstraints { make in
-            make.top.equalTo(deleteDailyRoutineButton.snp.bottom).offset(10)
-            make.leading.equalToSuperview().offset(23)
-            make.trailing.equalToSuperview().inset(23)
-            make.height.equalTo(44)
+            make.top.equalTo(deleteDailyRoutineButton.snp.bottom).offset(Layout.deleteAllRoutineButtonTopSpacing)
+            make.leading.equalToSuperview().offset(Layout.buttonHorizontalMargin)
+            make.trailing.equalToSuperview().inset(Layout.buttonHorizontalMargin)
+            make.height.equalTo(Layout.buttonHeight)
         }
     }
 }

--- a/Projects/Presentation/Sources/Home/View/Component/RoutineDeleteAlertView.swift
+++ b/Projects/Presentation/Sources/Home/View/Component/RoutineDeleteAlertView.swift
@@ -1,0 +1,111 @@
+//
+//  RoutineDeleteAlertView.swift
+//  Presentation
+//
+//  Created by 최정인 on 8/4/25.
+//
+
+import SnapKit
+import UIKit
+
+protocol RoutineDeleteAlertViewDelegate: AnyObject {
+    func routineDeleteAlertViewDidTapDeleteAllRoutine(_ sender: RoutineDeleteAlertView)
+    func routineDeleteAlertViewDidTapDeleteDailiyRoutine(_ sender: RoutineDeleteAlertView)
+}
+
+final class RoutineDeleteAlertView: UIView {
+
+    private enum Layout {
+
+    }
+
+    private let contentView = UIView()
+    private let deleteLabel = UILabel()
+    private let deleteDailyRoutineButton = UIButton()
+    private let deleteAllRoutineButton = UIButton()
+    weak var delegate: RoutineDeleteAlertViewDelegate?
+
+    init() {
+        super.init(frame: .zero)
+        configureAttribute()
+        configureLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureAttribute() {
+        contentView.backgroundColor = .white
+        contentView.layer.masksToBounds = true
+        contentView.layer.cornerRadius = 20
+
+        deleteLabel.text = "해당 루틴은\n반복 루틴으로 설정되어 있어요"
+        deleteLabel.numberOfLines = 2
+        deleteLabel.textAlignment = .center
+        deleteLabel.font = BitnagilFont(style: .body1, weight: .semiBold).font
+        deleteLabel.textColor = BitnagilColor.gray10
+
+        var deleteDailyRoutineButtonConfiguration = UIButton.Configuration.filled()
+        deleteDailyRoutineButtonConfiguration.baseBackgroundColor = .white
+        deleteDailyRoutineButtonConfiguration.background.cornerRadius = 8
+        deleteDailyRoutineButtonConfiguration.attributedTitle = AttributedString(
+            "당일만 삭제",
+            attributes: .init([.font: BitnagilFont(style: .body2, weight: .medium).font]))
+        deleteDailyRoutineButtonConfiguration.baseForegroundColor = BitnagilColor.navy500
+        deleteDailyRoutineButtonConfiguration.background.strokeColor = BitnagilColor.navy500
+        deleteDailyRoutineButtonConfiguration.background.strokeWidth = 1
+        deleteDailyRoutineButton.configuration = deleteDailyRoutineButtonConfiguration
+        deleteDailyRoutineButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            self.delegate?.routineDeleteAlertViewDidTapDeleteDailiyRoutine(self)
+        }, for: .touchUpInside)
+
+        var deleteAllRoutineButtonConfiguration = UIButton.Configuration.filled()
+        deleteAllRoutineButtonConfiguration.baseBackgroundColor = .white
+        deleteAllRoutineButtonConfiguration.background.cornerRadius = 8
+        deleteAllRoutineButtonConfiguration.attributedTitle = AttributedString(
+            "전체 루틴 삭제",
+            attributes: .init([.font: BitnagilFont(style: .body2, weight: .medium).font]))
+        deleteAllRoutineButtonConfiguration.baseForegroundColor = BitnagilColor.navy500
+        deleteAllRoutineButtonConfiguration.background.strokeColor = BitnagilColor.navy500
+        deleteAllRoutineButtonConfiguration.background.strokeWidth = 1
+        deleteAllRoutineButton.configuration = deleteAllRoutineButtonConfiguration
+        deleteAllRoutineButton.addAction(UIAction { [weak self] _ in
+            guard let self else { return }
+            self.delegate?.routineDeleteAlertViewDidTapDeleteAllRoutine(self)
+        }, for: .touchUpInside)
+    }
+
+    private func configureLayout() {
+        addSubview(contentView)
+
+        contentView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        [deleteLabel, deleteDailyRoutineButton, deleteAllRoutineButton].forEach {
+            contentView.addSubview($0)
+        }
+
+        deleteLabel.snp.makeConstraints { make in
+            make.height.equalTo(48)
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(23)
+        }
+
+        deleteDailyRoutineButton.snp.makeConstraints { make in
+            make.top.equalTo(deleteLabel.snp.bottom).offset(22)
+            make.leading.equalToSuperview().offset(23)
+            make.trailing.equalToSuperview().inset(23)
+            make.height.equalTo(44)
+        }
+
+        deleteAllRoutineButton.snp.makeConstraints { make in
+            make.top.equalTo(deleteDailyRoutineButton.snp.bottom).offset(10)
+            make.leading.equalToSuperview().offset(23)
+            make.trailing.equalToSuperview().inset(23)
+            make.height.equalTo(44)
+        }
+    }
+}

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -342,8 +342,12 @@ final class HomeView: BaseViewController<HomeViewModel> {
         viewModel.output.deleteRoutineResultPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isDeleteRoutine in
+                guard let self else { return }
                 if isDeleteRoutine {
-                    self?.toggleDeleteAlertView()
+                    if self.isShowingDeleteAlertView {
+                        self.toggleDeleteAlertView()
+                    }
+                    viewModel.action(input: .fetchRoutines)
                 }
             }
             .store(in: &cancellables)

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -75,6 +75,9 @@ final class HomeView: BaseViewController<HomeViewModel> {
     private let floatingMenu = FloatingMenuView()
     private var bottomSheet: CustomBottomSheet?
 
+    private var isShowingDeleteAlertView: Bool = false
+    private let deleteAlertView = RoutineDeleteAlertView()
+
     private var contentViewTopConstraint: Constraint?
     private var cancellables: Set<AnyCancellable>
 
@@ -183,6 +186,9 @@ final class HomeView: BaseViewController<HomeViewModel> {
 
         let dimmedViewTapGesture = UITapGestureRecognizer(target: self, action: #selector(tappedDimmedView))
         dimmedView.addGestureRecognizer(dimmedViewTapGesture)
+
+        deleteAlertView.delegate = self
+        deleteAlertView.isHidden = true
     }
 
     override func configureLayout() {
@@ -205,6 +211,8 @@ final class HomeView: BaseViewController<HomeViewModel> {
         view.addSubview(dimmedView)
         view.addSubview(floatingMenu)
         view.addSubview(floatingButton)
+
+        view.addSubview(deleteAlertView)
 
         homeLabel.snp.makeConstraints { make in
             make.top.equalTo(safeArea).offset(Layout.homeLabelTopSpacing)
@@ -291,6 +299,12 @@ final class HomeView: BaseViewController<HomeViewModel> {
 
         dimmedView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+
+        deleteAlertView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.height.equalTo(214)
+            make.width.equalTo(298)
         }
     }
 
@@ -440,8 +454,30 @@ final class HomeView: BaseViewController<HomeViewModel> {
         }
     }
 
+    private func toggleDeleteAlertView() {
+        isShowingDeleteAlertView.toggle()
+
+        deleteAlertView.isHidden = !isShowingDeleteAlertView
+        dimmedView.isHidden = !isShowingDeleteAlertView
+
+        if !isShowingDeleteAlertView {
+            viewModel.action(input: .selectRoutine(routine: nil))
+        }
+
+        UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseOut]) {
+            self.dimmedView.alpha = self.isShowingDeleteAlertView ? 1 : 0
+            self.deleteAlertView.alpha = self.isShowingDeleteAlertView ? 1 : 0
+        }
+    }
+
     @objc private func tappedDimmedView() {
-        toggleFloatingButton()
+        if isShowingFloatingMenu {
+            toggleFloatingButton()
+        }
+
+        if isShowingDeleteAlertView {
+            toggleDeleteAlertView()
+        }
     }
 
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
@@ -479,6 +515,7 @@ extension HomeView: RoutineViewDelegate {
         bottomSheet = CustomBottomSheet(contentViewController: routineDetailView, maxHeight: maxHeight)
         if let bottomSheet {
             present(bottomSheet, animated: true)
+            viewModel.action(input: .selectRoutine(routine: mainRoutine))
         }
     }
 
@@ -535,6 +572,29 @@ extension HomeView: RoutineDetailViewDelegate {
     }
     
     func routineDetailView(_ sender: RoutineDetailView, didDeleteRoutine routine: MainRoutine) {
-        // TODO: 루틴 삭제
+        if let bottomSheet {
+            bottomSheet.dismissBottomSheet()
+            self.bottomSheet = nil
+        }
+        isShowingDeleteAlertView = true
+
+        deleteAlertView.isHidden = false
+        deleteAlertView.alpha = 1.0
+
+        dimmedView.isHidden = false
+        dimmedView.alpha = 1.0
+    }
+}
+
+// MARK: RoutineDeleteAlertViewDelegate
+extension HomeView: RoutineDeleteAlertViewDelegate {
+    func routineDeleteAlertViewDidTapDeleteAllRoutine(_ sender: RoutineDeleteAlertView) {
+        viewModel.action(input: .deleteAllRoutine)
+        toggleDeleteAlertView()
+    }
+    
+    func routineDeleteAlertViewDidTapDeleteDailiyRoutine(_ sender: RoutineDeleteAlertView) {
+        viewModel.action(input: .deleteDailyRoutine)
+        toggleDeleteAlertView()
     }
 }

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -50,6 +50,8 @@ final class HomeView: BaseViewController<HomeViewModel> {
         static let tooltipViewHeight: CGFloat = 47
         static let routineDetailViewDefaultHeight: CGFloat = 367
         static let routineDetailViewSubRoutineHeight: CGFloat = 25
+        static let deleteAlertViewWidth: CGFloat = 298
+        static let deleteAlertViewHeight: CGFloat = 214
     }
 
     private let gradientLayer = CAGradientLayer()
@@ -303,8 +305,8 @@ final class HomeView: BaseViewController<HomeViewModel> {
 
         deleteAlertView.snp.makeConstraints { make in
             make.center.equalToSuperview()
-            make.height.equalTo(214)
-            make.width.equalTo(298)
+            make.width.equalTo(Layout.deleteAlertViewWidth)
+            make.height.equalTo(Layout.deleteAlertViewHeight)
         }
     }
 

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -339,6 +339,14 @@ final class HomeView: BaseViewController<HomeViewModel> {
             }
             .store(in: &cancellables)
 
+        viewModel.output.deleteRoutineResultPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isDeleteRoutine in
+                if isDeleteRoutine {
+                    self?.toggleDeleteAlertView()
+                }
+            }
+            .store(in: &cancellables)
     }
 
     // 홈 Graident 배경색을 설정합니다.
@@ -576,13 +584,12 @@ extension HomeView: RoutineDetailViewDelegate {
             bottomSheet.dismissBottomSheet()
             self.bottomSheet = nil
         }
-        isShowingDeleteAlertView = true
 
-        deleteAlertView.isHidden = false
-        deleteAlertView.alpha = 1.0
-
-        dimmedView.isHidden = false
-        dimmedView.alpha = 1.0
+        if routine.repeatDay.isEmpty {
+            viewModel.action(input: .deleteDailyRoutine)
+        } else {
+            toggleDeleteAlertView()
+        }
     }
 }
 
@@ -590,11 +597,9 @@ extension HomeView: RoutineDetailViewDelegate {
 extension HomeView: RoutineDeleteAlertViewDelegate {
     func routineDeleteAlertViewDidTapDeleteAllRoutine(_ sender: RoutineDeleteAlertView) {
         viewModel.action(input: .deleteAllRoutine)
-        toggleDeleteAlertView()
     }
     
     func routineDeleteAlertViewDidTapDeleteDailiyRoutine(_ sender: RoutineDeleteAlertView) {
         viewModel.action(input: .deleteDailyRoutine)
-        toggleDeleteAlertView()
     }
 }

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -605,7 +605,7 @@ extension HomeView: RoutineDeleteAlertViewDelegate {
         viewModel.action(input: .deleteAllRoutine)
     }
     
-    func routineDeleteAlertViewDidTapDeleteDailiyRoutine(_ sender: RoutineDeleteAlertView) {
+    func routineDeleteAlertViewDidTapDeleteDailyRoutine(_ sender: RoutineDeleteAlertView) {
         viewModel.action(input: .deleteDailyRoutine)
     }
 }

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -80,8 +80,7 @@ final class HomeViewModel: ViewModel {
             selectedRoutineSubject.send(routine)
 
         case .deleteDailyRoutine:
-            // TODO: 당일 삭제 로직 구현
-            print("\(selectedRoutineSubject.value?.title)")
+            deleteDailyRoutine()
 
         case .deleteAllRoutine:
             deleteAllRoutine()
@@ -167,6 +166,29 @@ final class HomeViewModel: ViewModel {
             do {
                 try await routineUseCase.deleteAllRoutine(routineId: routineId)
                 selectedRoutineSubject.send(nil)
+                deleteRoutineResultSubject.send(true)
+            } catch {
+                deleteRoutineResultSubject.send(false)
+            }
+        }
+    }
+
+    private func deleteDailyRoutine() {
+        guard let routine = selectedRoutineSubject.value
+        else { return }
+
+        let deleteSubRoutineEntity = routine.subRoutines.map({
+            DeleteSubRoutineEntity(subRoutineId: $0.id, routineCompletionId: $0.completionId) })
+        let deleteRoutinEntity = DeleteRoutineEntity(
+            routineId: routine.id,
+            routineCompletionId: routine.completionId,
+            historySeq: routine.historySeq,
+            performedDate: today.convertToString(dateType: .yearMonthDate),
+            subRoutineInfosForDelete: deleteSubRoutineEntity)
+
+        Task {
+            do {
+                try await routineUseCase.deleteDailyRoutine(routine: deleteRoutinEntity)
                 deleteRoutineResultSubject.send(true)
             } catch {
                 deleteRoutineResultSubject.send(false)

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -184,6 +184,7 @@ final class HomeViewModel: ViewModel {
             routineCompletionId: routine.completionId,
             historySeq: routine.historySeq,
             performedDate: today.convertToString(dateType: .yearMonthDate),
+            routineType: routine.routineType,
             subRoutineInfosForDelete: deleteSubRoutineEntity)
 
         Task {

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -25,6 +25,7 @@ final class HomeViewModel: ViewModel {
         let fetchRoutineResultPublisher: AnyPublisher<Bool, Never>
         let routinesPublisher: AnyPublisher<[MainRoutine], Never>
         let emotionPublisher: AnyPublisher<Emotion?, Never>
+        let deleteRoutineResultPublisher: AnyPublisher<Bool, Never>
     }
 
     private(set) var output: Output
@@ -34,6 +35,7 @@ final class HomeViewModel: ViewModel {
     private let routinesSubject = CurrentValueSubject<[MainRoutine], Never>([])
     private let selectedRoutineSubject = CurrentValueSubject<MainRoutine?, Never>(nil)
     private let emotionSubject = CurrentValueSubject<Emotion?, Never>(nil)
+    private let deleteRoutineResultSubject = PassthroughSubject<Bool, Never>()
 
     private let calendar = Calendar.current
     private let today = Date()
@@ -55,7 +57,8 @@ final class HomeViewModel: ViewModel {
             nicknamePublisher: nicknameSubject.eraseToAnyPublisher(),
             fetchRoutineResultPublisher: fetchRoutineResultSubject.eraseToAnyPublisher(),
             routinesPublisher: routinesSubject.eraseToAnyPublisher(),
-            emotionPublisher: emotionSubject.eraseToAnyPublisher()
+            emotionPublisher: emotionSubject.eraseToAnyPublisher(),
+            deleteRoutineResultPublisher: deleteRoutineResultSubject.eraseToAnyPublisher()
         )
     }
 
@@ -81,8 +84,7 @@ final class HomeViewModel: ViewModel {
             print("\(selectedRoutineSubject.value?.title)")
 
         case .deleteAllRoutine:
-            // TODO: 전체 루틴 삭제 로직 구현
-            print("\(selectedRoutineSubject.value?.title)")
+            deleteAllRoutine()
         }
     }
 
@@ -155,5 +157,20 @@ final class HomeViewModel: ViewModel {
     private func calculateDate(for date: Date, offset week: Int) -> Date {
         let endDate = calendar.date(byAdding: .weekOfYear, value: week, to: date) ?? date
         return endDate
+    }
+
+    private func deleteAllRoutine() {
+        guard let routineId = selectedRoutineSubject.value?.id
+        else { return }
+
+        Task {
+            do {
+                try await routineUseCase.deleteAllRoutine(routineId: routineId)
+                selectedRoutineSubject.send(nil)
+                deleteRoutineResultSubject.send(true)
+            } catch {
+                deleteRoutineResultSubject.send(false)
+            }
+        }
     }
 }

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -15,6 +15,9 @@ final class HomeViewModel: ViewModel {
         case fetchRoutines
         case fetchDailyRoutines(date: Date)
         case fetchEmotion
+        case selectRoutine(routine: MainRoutine?)
+        case deleteDailyRoutine
+        case deleteAllRoutine
     }
 
     struct Output {
@@ -29,6 +32,7 @@ final class HomeViewModel: ViewModel {
     private let nicknameSubject = CurrentValueSubject<String, Never>("")
     private let fetchRoutineResultSubject = PassthroughSubject<Bool, Never>()
     private let routinesSubject = CurrentValueSubject<[MainRoutine], Never>([])
+    private let selectedRoutineSubject = CurrentValueSubject<MainRoutine?, Never>(nil)
     private let emotionSubject = CurrentValueSubject<Emotion?, Never>(nil)
 
     private let calendar = Calendar.current
@@ -68,6 +72,17 @@ final class HomeViewModel: ViewModel {
 
         case .fetchEmotion:
             fetchEmotion()
+
+        case .selectRoutine(let routine):
+            selectedRoutineSubject.send(routine)
+
+        case .deleteDailyRoutine:
+            // TODO: 당일 삭제 로직 구현
+            print("\(selectedRoutineSubject.value?.title)")
+
+        case .deleteAllRoutine:
+            // TODO: 전체 루틴 삭제 로직 구현
+            print("\(selectedRoutineSubject.value?.title)")
         }
     }
 

--- a/Projects/Presentation/Sources/Login/View/LoginView.swift
+++ b/Projects/Presentation/Sources/Login/View/LoginView.swift
@@ -132,7 +132,7 @@ final class LoginView: BaseViewController<LoginViewModel> {
     private func appleLogin() {
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
-        request.requestedScopes = [.fullName]
+        request.requestedScopes = [.fullName, .email]
 
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

루틴 삭제를 구현하였습니다.   

- 당일 루틴인 경우 (온보딩에서 추가한 루틴) : Alert View 없이 바로 삭제
- 반복 설정이 된 루틴인 경우 (루틴 등록에서 직접 등록한 루틴) : Alert View를 통해 당일만 삭제할지, 반복되는 루틴 전체 삭제할지 선택하여 삭제     



## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

**루틴 삭제 Alert View**      
| iPhone SE3 | iPhone 13 mini | iPhone 16 Pro |
|--------|--------|--------|
| <img width="250" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2025-08-05 at 00 55 58" src="https://github.com/user-attachments/assets/91159871-f0c4-4373-a5be-fbdafe2676de" /> | <img width="250" alt="Simulator Screenshot - iPhone 13 mini - 2025-08-05 at 00 53 48" src="https://github.com/user-attachments/assets/4e30e335-5096-4b54-8640-add506686bbb" /> | <img width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-05 at 00 50 17" src="https://github.com/user-attachments/assets/cc13d5d1-8144-4e0f-9042-292928e94f3e" /> |


**전체 흐름**      

https://github.com/user-attachments/assets/6b81e905-74f3-4701-bc17-81ece9629a4f



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- RoutineDeleteAlertView UI 구현
- RoutineEndpoint에 루틴 당일 삭제, 루틴 전체 삭제 case 추가
- RoutineRepository, RoutineUseCase, HomeViewModel에 삭제 로직 추가


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

- 온보딩을 통해 등록한 루틴 삭제
- 반복 루틴의 당일 삭제
- 반복 루틴의 전체 삭제

를 테스트 해보았습니다.


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### 1. DTO <-> Entity 

[띵의 PR](https://github.com/YAPP-Github/Bitnagil-iOS/pull/33)에서 말씀해주신 요 부분 ..... 
저도 마찬가지로 DIP 라고는 하지만 Entity가 DTO를 너무 알고 있어요 ㅠㅠ    

배포 후 꼭 개선할게요 ....  


그리고 일단 DTO -> Entity는 일단 현상 유지 했지만 ... Entity -> DTO는 repository에서 하게 했슴니다 !!!!




## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #T3-134


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


**새로운 기능**
- 루틴 삭제 시 "당일만 삭제"와 "전체 루틴 삭제"를 선택할 수 있는 삭제 확인 알림창이 추가되었습니다.
- 홈 화면에서 루틴 삭제 시 반복 루틴 여부에 따라 삭제 옵션을 안내합니다.
- 루틴 및 서브루틴 정보에 삭제 관련 데이터가 확장되었습니다.
- 루틴 삭제 기능이 도메인, 데이터 소스, 뷰모델, 유즈케이스 전반에 걸쳐 추가되어, 사용자가 루틴 전체 또는 당일 루틴만 선택적으로 삭제할 수 있습니다.

**버그 수정**
- Apple 로그인 시 이메일 정보도 함께 요청하도록 개선되었습니다.

**기타**
- 불필요한 파일이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->