### PR TITLE
[Feat] 온보딩 여부 저장 및 분기 처리

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -54,10 +54,22 @@ extension SceneDelegate: SplashViewDelegate {
         guard let userDataRepository = DIContainer.shared.resolve(type: UserDataRepositoryProtocol.self)
         else { fatalError("userDataRepository 의존성이 등록되지 않았습니다.") }
 
+        guard let onboardingRepository = DIContainer.shared.resolve(type: OnboardingRepositoryProtocol.self)
+        else { fatalError("onboardingRepository 의존성이 등록되지 않았습니다.") }
+
         Task { @MainActor in
             let isLogined = await userDataRepository.reissueToken()
             if isLogined {
-                window?.rootViewController = TabBarView()
+                if onboardingRepository.isOnboardingDone() {
+                    window?.rootViewController = TabBarView()
+                } else {
+                    guard let onboardingViewModel = DIContainer.shared.resolve(type: OnboardingViewModel.self) else {
+                        fatalError("onboardingViewModel 의존성이 등록되지 않았습니다.")
+                    }
+                    let onboardingView = OnboardingView(viewModel: onboardingViewModel, onboarding: .time)
+                    let navigationController = UINavigationController(rootViewController: onboardingView)
+                    window?.rootViewController = navigationController
+                }
             } else {
                 let introView = IntroView()
                 let navigationController = UINavigationController(rootViewController: introView)

--- a/Projects/DataSource/Sources/Common/Enum/UserDefaultsKey.swift
+++ b/Projects/DataSource/Sources/Common/Enum/UserDefaultsKey.swift
@@ -8,5 +8,5 @@
 enum UserDefaultsKey: String {
     case nickname
     case socialLoginType
-    case profileImageUrl
+    case onboarding
 }

--- a/Projects/DataSource/Sources/Common/Error/UserError.swift
+++ b/Projects/DataSource/Sources/Common/Error/UserError.swift
@@ -12,9 +12,9 @@ enum UserError: Error, CustomStringConvertible {
     case socialLoginTypeSaveFailed
     case socialLoginTypeLoadFailed
     case socialLoginTypeRemoveFailed
-    case profileImageUrlSaveFailed
-    case profileImageUrlLoadFailed
-    case profileImageUrlRemoveFailed
+    case onboardingSaveFailed
+    case onboardingLoadFailed
+    case onboardingRemoveFailed
     case unknown(error: Error)
 
     var description: String {
@@ -31,12 +31,12 @@ enum UserError: Error, CustomStringConvertible {
             return "소셜 로그인 타입 불러오기에 실패했습니다."
         case .socialLoginTypeRemoveFailed:
             return "소셜 로그인 타입 삭제 실패했습니다."
-        case .profileImageUrlSaveFailed:
-            return "유저 프로필 저장 실패했습니다."
-        case .profileImageUrlLoadFailed:
-            return "유저 프로필 불러오기에 실패했습니다."
-        case .profileImageUrlRemoveFailed:
-            return "유저 프로필 삭제 실패했습니다."
+        case .onboardingSaveFailed:
+            return "온보딩 여부 저장 실패했습니다."
+        case .onboardingLoadFailed:
+            return "온보딩 여부 불러오기에 실패했습니다."
+        case .onboardingRemoveFailed:
+            return "온보딩 여부를 삭제하는데 실패했습니다."
         case .unknown(let error):
             return "알 수 없는 에러가 발생했습니다. \(error.localizedDescription)"
         }

--- a/Projects/DataSource/Sources/Repository/AuthRepository.swift
+++ b/Projects/DataSource/Sources/Repository/AuthRepository.swift
@@ -138,13 +138,6 @@ final class AuthRepository: AuthRepositoryProtocol {
         }
     }
 
-    // UserDefaults에 프로필 이미지를 저장합니다.
-    private func saveUserProfileImageUrl(profileImageUrl: URL) throws {
-        guard userDefaultsStorage.save(profileImageUrl.absoluteString, forKey: UserDefaultsKey.profileImageUrl.rawValue) else {
-            throw UserError.profileImageUrlSaveFailed
-        }
-    }
-
     // UserDefaults에 저장된 유저 정보(닉네임, 소셜 로그인 타입, 프로필 이미지)를 삭제합니다.
     private func removeUserInfo() throws {
         guard userDefaultsStorage.remove(forKey: UserDefaultsKey.nickname.rawValue) else {
@@ -155,8 +148,9 @@ final class AuthRepository: AuthRepositoryProtocol {
             throw UserError.socialLoginTypeRemoveFailed
         }
 
-        guard userDefaultsStorage.remove(forKey: UserDefaultsKey.profileImageUrl.rawValue) else {
-            throw UserError.profileImageUrlRemoveFailed
+        guard userDefaultsStorage.remove(forKey: UserDefaultsKey.onboarding.rawValue) else {
+            throw UserError.onboardingRemoveFailed
         }
+
     }
 }

--- a/Projects/DataSource/Sources/Repository/OnboardingRepository.swift
+++ b/Projects/DataSource/Sources/Repository/OnboardingRepository.swift
@@ -9,14 +9,25 @@ import Domain
 
 final class OnboardingRepository: OnboardingRepositoryProtocol {
     private let networkService = NetworkService.shared
+    private let userDefaultsStorage = UserDefaultsStorage.shared
 
     func registerOnboarding(onboardingChoices: [String : String]) async throws -> [RecommendedRoutineEntity] {
         let endpoint = OnboardingEndpoint.registerOnboarding(choices: onboardingChoices)
         guard let response = try await networkService.request(endpoint: endpoint, type: RecommendedRoutineListResponseDTO.self)
         else { return [] }
 
+        guard userDefaultsStorage.save(true, forKey: UserDefaultsKey.onboarding.rawValue)
+        else { throw UserError.onboardingSaveFailed }
+
         let recommendedRoutineEntity = response.recommendedRoutines.compactMap({ $0.toRecommendedRoutineEntity() })
         return recommendedRoutineEntity
+    }
+
+    func isOnboardingDone() -> Bool {
+        guard let isOnboardingDone: Bool = userDefaultsStorage.load(forKey: UserDefaultsKey.onboarding.rawValue)
+        else { return false }
+
+        return isOnboardingDone
     }
 
     func registerRecommendedRoutines(selectedRoutines: [Int]) async throws {

--- a/Projects/Domain/Sources/Protocol/Repository/OnboardingRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/OnboardingRepositoryProtocol.swift
@@ -14,4 +14,8 @@ public protocol OnboardingRepositoryProtocol {
     /// 선택한 추천 루틴을 등록합니다.
     /// - Parameter selectedRoutines: 선택한 추천 루틴 ID 목록
     func registerRecommendedRoutines(selectedRoutines: [Int]) async throws
+
+    /// 온보딩 여부를 반환합니다.
+    /// - Returns: 온보딩 여부
+    func isOnboardingDone() -> Bool
 }

--- a/Projects/Presentation/Sources/Common/Extension/UIViewController+.swift
+++ b/Projects/Presentation/Sources/Common/Extension/UIViewController+.swift
@@ -46,6 +46,7 @@ extension UIViewController {
             action: #selector(popViewController))
         backButton.tintColor = .black
         navigationItem.leftBarButtonItem = backButton
+        changeNavigationBackground(color: .white)
     }
 
     private func configureCustomBackButton() {
@@ -56,12 +57,14 @@ extension UIViewController {
             action: #selector(popTwoViewControllers))
         backButton.tintColor = .black
         navigationItem.leftBarButtonItem = backButton
+        changeNavigationBackground(color: .white)
     }
 
     private func configureProgressNavigationBar(step: Int, stepCount: Int) {
         self.title = ""
         let progressView = ProgressBarView(step: step, stepCount: stepCount)
         navigationItem.titleView = progressView
+        changeNavigationBackground(color: BitnagilColor.gray99)
     }
 
     @objc private func popViewController() {
@@ -80,6 +83,17 @@ extension UIViewController {
 
         let targetViewController = viewControllers[viewControllers.count - 3]
         navigationController.popToViewController(targetViewController, animated: true)
+    }
+
+    private func changeNavigationBackground(color: UIColor?) {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = color
+        appearance.shadowColor = .clear
+
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
     }
 
     // MARK: - BottomSheet

--- a/Projects/Presentation/Sources/Common/Extension/UIViewController+.swift
+++ b/Projects/Presentation/Sources/Common/Extension/UIViewController+.swift
@@ -10,13 +10,6 @@ import UIKit
 extension UIViewController {
     // MARK: - NavigationBar
     func configureNavigationBar(navigationStyle: NavigationBarStyle) {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundEffect = .none
-        appearance.configureWithOpaqueBackground()
-        appearance.shadowColor = .clear
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-
         switch navigationStyle {
         case .hidden:
             navigationController?.setNavigationBarHidden(true, animated: false)

--- a/Projects/Presentation/Sources/Common/Extension/UIViewController+.swift
+++ b/Projects/Presentation/Sources/Common/Extension/UIViewController+.swift
@@ -28,6 +28,11 @@ extension UIViewController {
             navigationController?.setNavigationBarHidden(false, animated: false)
             configureCustomBackButton()
             configureProgressNavigationBar(step: step, stepCount: stepCount)
+
+        case .withPrograssBarWithoutBackButton(let step, let stepCount):
+            navigationController?.setNavigationBarHidden(false, animated: false)
+            navigationController?.navigationItem.setHidesBackButton(true, animated: false)
+            configureProgressNavigationBar(step: step, stepCount: stepCount)
         }
     }
 
@@ -101,4 +106,5 @@ enum NavigationBarStyle {
     case withBackButton(title: String)
     case withPrograssBar(step: Int, stepCount: Int)
     case withPrograssBarWithCustomBackButton(step: Int, stepCount: Int)
+    case withPrograssBarWithoutBackButton(step: Int, stepCount: Int)
 }

--- a/Projects/Presentation/Sources/Common/Protocol/BaseViewController.swift
+++ b/Projects/Presentation/Sources/Common/Protocol/BaseViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class BaseViewController<T: ViewModel>: UIViewController {
+public class BaseViewController<T: ViewModel>: UIViewController {
     let viewModel: T
 
     init(viewModel: T) {
@@ -19,7 +19,7 @@ class BaseViewController<T: ViewModel>: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
 
         configureAttribute()

--- a/Projects/Presentation/Sources/Common/Protocol/ViewModel.swift
+++ b/Projects/Presentation/Sources/Common/Protocol/ViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by 최정인 on 6/26/25.
 //
 
-protocol ViewModel {
+public protocol ViewModel {
     associatedtype Input
     associatedtype Output
 

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -102,6 +102,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        configureNavigationBar(navigationStyle: .hidden)
         viewModel.action(input: .fetchEmotion)
     }
 

--- a/Projects/Presentation/Sources/Login/View/IntroView.swift
+++ b/Projects/Presentation/Sources/Login/View/IntroView.swift
@@ -5,6 +5,7 @@
 //  Created by 최정인 on 7/6/25.
 //
 
+import Domain
 import Shared
 import SnapKit
 import UIKit
@@ -48,10 +49,13 @@ public final class IntroView: UIViewController {
         graphView.image = BitnagilGraphic.introGraphic
 
         startButton.addAction(UIAction { [weak self] _ in
-            guard let loginViewModel = DIContainer.shared.resolve(type: LoginViewModel.self) else {
-                fatalError("loginViewModel 의존성이 등록되지 않았습니다.")
-            }
-            let loginView = LoginView(viewModel: loginViewModel)
+            guard let onboardingRepository = DIContainer.shared.resolve(type: OnboardingRepositoryProtocol.self)
+            else { fatalError("onboardingRepository 의존성이 등록되지 않았습니다.") }
+
+            guard let loginViewModel = DIContainer.shared.resolve(type: LoginViewModel.self)
+            else { fatalError("loginViewModel 의존성이 등록되지 않았습니다.") }
+
+            let loginView = LoginView(onboardingRepository: onboardingRepository, viewModel: loginViewModel)
             self?.navigationController?.pushViewController(loginView, animated: true)
         }, for: .touchUpInside)
     }

--- a/Projects/Presentation/Sources/Login/View/LoginView.swift
+++ b/Projects/Presentation/Sources/Login/View/LoginView.swift
@@ -7,6 +7,7 @@
 
 import AuthenticationServices
 import Combine
+import Domain
 import Shared
 import SnapKit
 import UIKit
@@ -31,8 +32,10 @@ final class LoginView: BaseViewController<LoginViewModel> {
     private let kakaoLoginButton = SocialLoginButton(socialType: .kakao)
     private let appleLoginButton = SocialLoginButton(socialType: .apple)
     private var cancellables: Set<AnyCancellable>
+    private let onboardingRepository: OnboardingRepositoryProtocol
 
-    override init(viewModel: LoginViewModel) {
+    init(onboardingRepository: OnboardingRepositoryProtocol, viewModel: LoginViewModel) {
+        self.onboardingRepository = onboardingRepository
         cancellables = []
         super.init(viewModel: viewModel)
     }
@@ -119,11 +122,18 @@ final class LoginView: BaseViewController<LoginViewModel> {
                     let agreementView = TermsAgreementView(viewModel: self.viewModel)
                     self.navigationController?.pushViewController(agreementView, animated: true)
                 } else {
-                    guard let onboardingViewModel = DIContainer.shared.resolve(type: OnboardingViewModel.self) else {
-                        fatalError("onboardingViewModel 의존성이 등록되지 않았습니다.")
+                    if onboardingRepository.isOnboardingDone() {
+                        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                            window.rootViewController = TabBarView()
+                        }
+                    } else {
+                        guard let onboardingViewModel = DIContainer.shared.resolve(type: OnboardingViewModel.self) else {
+                            fatalError("onboardingViewModel 의존성이 등록되지 않았습니다.")
+                        }
+                        let onboardingView = OnboardingView(viewModel: onboardingViewModel, onboarding: .time)
+                        self.navigationController?.pushViewController(onboardingView, animated: true)
                     }
-                    let onboardingView = OnboardingView(viewModel: onboardingViewModel, onboarding: .time)
-                    self.navigationController?.pushViewController(onboardingView, animated: true)
                 }
             }
             .store(in: &cancellables)

--- a/Projects/Presentation/Sources/MyPage/View/MypageView.swift
+++ b/Projects/Presentation/Sources/MyPage/View/MypageView.swift
@@ -39,6 +39,18 @@ final class MypageView: BaseViewController<MypageViewModel> {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
+
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
+    }
+
     override func configureAttribute() {
         view.backgroundColor = .white
         navigationItem.rightBarButtonItem = settingButton

--- a/Projects/Presentation/Sources/Onboarding/View/OnboardingView.swift
+++ b/Projects/Presentation/Sources/Onboarding/View/OnboardingView.swift
@@ -53,10 +53,6 @@ public final class OnboardingView: BaseViewController<OnboardingViewModel> {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 

--- a/Projects/Presentation/Sources/Onboarding/View/OnboardingView.swift
+++ b/Projects/Presentation/Sources/Onboarding/View/OnboardingView.swift
@@ -10,7 +10,7 @@ import Domain
 import SnapKit
 import UIKit
 
-final class OnboardingView: BaseViewController<OnboardingViewModel> {
+public final class OnboardingView: BaseViewController<OnboardingViewModel> {
 
     private enum Layout {
         static let horizontalMargin: CGFloat = 20
@@ -38,7 +38,7 @@ final class OnboardingView: BaseViewController<OnboardingViewModel> {
 
     private let isFromMypage: Bool
     private var cancellables: Set<AnyCancellable>
-    init(
+    public init(
         viewModel: OnboardingViewModel,
         onboarding: OnboardingType,
         isFromMypage: Bool = false
@@ -53,11 +53,11 @@ final class OnboardingView: BaseViewController<OnboardingViewModel> {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         let stepCount = OnboardingType.allCases.count + 1
@@ -66,7 +66,7 @@ final class OnboardingView: BaseViewController<OnboardingViewModel> {
         self.viewModel.action(input: .fetchOnboardingChoice(onboarding: onboarding))
     }
 
-    override func viewDidLayoutSubviews() {
+    public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
         if !isLayoutConfigured {

--- a/Projects/Presentation/Sources/Onboarding/View/OnboardingView.swift
+++ b/Projects/Presentation/Sources/Onboarding/View/OnboardingView.swift
@@ -57,7 +57,11 @@ public final class OnboardingView: BaseViewController<OnboardingViewModel> {
         super.viewWillAppear(animated)
 
         let stepCount = OnboardingType.allCases.count + 1
-        configureNavigationBar(navigationStyle: .withPrograssBar(step: onboarding.step, stepCount: stepCount))
+        if !isFromMypage && onboarding == .time {
+            configureNavigationBar(navigationStyle: .withPrograssBarWithoutBackButton(step: onboarding.step, stepCount: stepCount))
+        } else {
+            configureNavigationBar(navigationStyle: .withPrograssBar(step: onboarding.step, stepCount: stepCount))
+        }
 
         self.viewModel.action(input: .fetchOnboardingChoice(onboarding: onboarding))
     }

--- a/Projects/Presentation/Sources/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Projects/Presentation/Sources/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -9,15 +9,15 @@ import Combine
 import Domain
 import Shared
 
-final class OnboardingViewModel: ViewModel {
-    enum Input {
+public final class OnboardingViewModel: ViewModel {
+    public enum Input {
         case selectOnboardingChoice(selectedChoice: OnboardingChoiceType)
         case fetchOnboardingChoice(onboarding: OnboardingType)
         case fetchOnboardingChoices
         case makeOnboardingResult
     }
 
-    struct Output {
+    public struct Output {
         let timeOnboardingChoicePublisher: AnyPublisher<OnboardingChoiceType?, Never>
         let frequencyOnboardingChoicePublisher: AnyPublisher<OnboardingChoiceType?, Never>
         let feelingOnboardingChoicePublisher: AnyPublisher<Set<OnboardingChoiceType>, Never>
@@ -48,7 +48,7 @@ final class OnboardingViewModel: ViewModel {
         )
     }
 
-    func action(input: Input) {
+    public func action(input: Input) {
         switch input {
         case .selectOnboardingChoice(let selectedChoice):
             selectChoice(choice: selectedChoice)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

- 온보딩 여부를 UserDefaults에 저장하여 분기 처리를 하도록 구현하였습니다. 
- 온보딩 View의 네비게이션 바 배경색을 맞춰주었습니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
| 수정 전 | 수정 후 |
|--------|--------|
| <img width="250" alt="Simulator Screenshot - iPhone 13 mini - 2025-08-06 at 22 00 53" src="https://github.com/user-attachments/assets/bd5bd740-8cc7-44fc-bc69-502e21c11957" /> | <img width="250" alt="Simulator Screenshot - iPhone 13 mini - 2025-08-06 at 21 33 51" src="https://github.com/user-attachments/assets/4431d195-54e6-4261-a37b-5b5a022914c0" /> |

머가 달라졌게요 ㅎㅎㅎㅎ..

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- OnboardingRepository에 Onboarding 여부 값 저장하는 로직 추가
- 회원 탈퇴 시 Onboarding 여부 값 삭제 로직 추가
- OnboardingView navigation bar 배경 색상 변경

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

- 로그인 후 온보딩 하지 않고 앱을 날린 후 다시 앱 접속 > (온보딩을 진행하지 않았으므로) 온보딩 화면 ⭕️
- 로그인 후 온보딩 완료 후 홈 접속, 이후 앱 날린 후 다시 앱 접속 > (온보딩을 진행하였으므로 온보딩 ❌) 홈 화면 
- 탈퇴 후 (임의로 탈퇴 로직 붙였습니다!!) 로그인 시도 > 온보딩 화면 ⭕️
- 로그아웃 후 (임의로 로그아웃 로직 붙였습니다!!) 로그인 시도 > 온보딩 화면 ❌, 홈 화면 


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

**1. MypageView**

MypageView를 제가 조금 건드렸어요 .. !!!  
- **건들인 이유**: 온보딩 View(목표 재설정)에서 navigationBar의 색상을 바꿉니다. > 그리고 다시 MypageView로 돌아오면 변경된 색상으로 남아있어요 .. (`BitnagilColor.gray99`)
- **무엇을 건들였나** :  viewWillAppear를 override해서 navigationBar의 색상을 white로 변경해주었습니다.
다른 View들은 보통 `UIViewController+` 파일에서 navigationBar 세팅을 해주기 때문에 다른 뷰들에 대한 변경은 `UIViewController+` 파일에 있습니다 !!

```swift
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    let appearance = UINavigationBarAppearance()
    appearance.configureWithOpaqueBackground()
    appearance.backgroundColor = .white
    appearance.shadowColor = .clear

    navigationController?.navigationBar.standardAppearance = appearance
    navigationController?.navigationBar.scrollEdgeAppearance = appearance
    navigationController?.navigationBar.compactAppearance = appearance
}
```

<br>

**2. BaseViewController, ViewModel 접근제어자 public로 변경**   

온보딩 여부에 따라 분기처리가 이뤄어져야 해서 SceneDelegate에서 온보딩 뷰를 접근해야 합니다.   

원래는 SceneDelegate에서 접근하는 뷰는 IntroView, TabBarView 뿐이라서 BaseViewController, ViewModel의 접근 제어자를 internal로 가져가도 괜찮았지만 .. 
SceneDelegate에서 온보딩 뷰를 접근해야 하므로 BaseViewController, ViewModel 녀석들을 public으로 변경이 필수적으로 필요했습니다 .. ㅜㅜ   

```swift
Task { @MainActor in
    let isLogined = await userDataRepository.reissueToken()
    if isLogined {
        if onboardingRepository.isOnboardingDone() {
            window?.rootViewController = TabBarView()
        } else {
            guard let onboardingViewModel = DIContainer.shared.resolve(type: OnboardingViewModel.self) else {
                fatalError("onboardingViewModel 의존성이 등록되지 않았습니다.")
            }
            let onboardingView = OnboardingView(viewModel: onboardingViewModel, onboarding: .time)
            let navigationController = UINavigationController(rootViewController: onboardingView)
            window?.rootViewController = navigationController
        }
    } else {
        let introView = IntroView()
        let navigationController = UINavigationController(rootViewController: introView)
        window?.rootViewController = navigationController
    }
}
```


<br>

**3. 온보딩 여부 함수 OnboardingRepository에만 존재**   

현재 약간 뒤죽박죽하지만 UseCase가 단순 Repository를 passthrough하는 경우 Repository만 사용하기로 결정되었습니다 !!     
그래서 온보딩 여부 확인하는 함수는 OnboardingRepository에만 존재합니다.  

그러다 보니 onboardingRepository 인스턴스가 이곳 저곳 여러번 생성되어요 .. (온보딩 분기처리 해야 하는 뷰에 전부)  
- SceneDelegate
- LoginView
- 더 있을 수 있음 .......


이것의 해결법은 약간 리뷰 노트 4번과 이어져요 ... 


<br>

**4. 온보딩을 수행하지 않은 유저에 대한 케이스**   

테스트 케이스 1번을 보면 **"로그인 후 온보딩 하지 않고 앱을 날린 후 다시 앱 접속 > (온보딩을 진행하지 않았으므로) 온보딩 화면 ⭕️"** 이렇습니다.       
하지만 온보딩 화면에는 첫번째 부터 백버튼이 존재하여, 앱 처음 진입점이 온보딩 화면이지만 백버튼이 존재하는 이상한 현상 발생 ... 
백버튼을 눌러도 아무 현상이 일어나지 않는 이슈 발생 ...

이는 어찌 해결해야 할까요??    
1. 온보딩 여부를 아예 체크하지 말자
2. 로그인 이후 온보딩 여부만 체크하고, 앱 진입점에서는 온보딩 여부를 체크하지 말기  
3. 백버튼 임의로 없애자 (디자이너 팀에게 문의해야 함)    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 온보딩 완료 여부를 확인하여, 완료 시 메인 화면(TabBarView)로, 미완료 시 온보딩 화면으로 이동하는 흐름이 추가되었습니다.
  * 로그인 성공 시 온보딩 진행 여부에 따라 다음 화면이 결정됩니다.
  * 네비게이션 바에 백 버튼 없는 진행 바 스타일이 새로 추가되었습니다.

* **버그 수정**
  * 네비게이션 바의 배경색 및 그림자 설정이 일관되게 적용되어 화면 전환 시 UI가 개선되었습니다.
  * 마이페이지 화면 진입 시 네비게이션 바 배경색이 흰색으로 설정되어 UI 일관성이 향상되었습니다.

* **공개 범위 변경**
  * 여러 View, ViewModel, Protocol의 접근 제한자가 public으로 변경되어 외부 모듈에서 접근이 가능해졌습니다.

* **기타**
  * 온보딩 관련 UserDefaults 저장 및 오류 처리 방식이 개선되었습니다.
  * 온보딩 완료 여부 확인 메서드가 추가되어 상태 관리가 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->