### PR TITLE
[Feat-T3-144] 루틴 완료 로직 구현

### DIFF
--- a/Projects/DataSource/Sources/DTO/RoutineCompletionDTO.swift
+++ b/Projects/DataSource/Sources/DTO/RoutineCompletionDTO.swift
@@ -1,0 +1,18 @@
+//
+//  RoutineCompletionDTO.swift
+//  DataSource
+//
+//  Created by 최정인 on 8/6/25.
+//
+
+struct RoutineCompletionListDTO: Encodable {
+    let performedDate: String
+    let routineCompletionInfos: [RoutineCompletionDTO]
+}
+
+struct RoutineCompletionDTO: Encodable {
+    let routineId: String
+    let completeYn: Bool
+    let historySeq: Int
+    let routineType: String
+}

--- a/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/RoutineEndpoint.swift
@@ -12,6 +12,7 @@ enum RoutineEndpoint {
     case updateRoutine(routine: RoutineUpdateDTO)
     case deleteAllRoutine(routineId: String)
     case deleteDailyRoutine(routine: DeleteRoutineDTO)
+    case updateRoutineCompletion(routines: RoutineCompletionListDTO)
 }
 
 extension RoutineEndpoint: Endpoint {
@@ -27,6 +28,8 @@ extension RoutineEndpoint: Endpoint {
             "\(baseURL)/\(routineId)"
         case .deleteDailyRoutine:
             "\(baseURL)/day"
+        case .updateRoutineCompletion:
+            "\(baseURL)/completions"
         default:
             baseURL
         }
@@ -34,7 +37,7 @@ extension RoutineEndpoint: Endpoint {
     
     var method: HTTPMethod {
         switch self {
-        case .createRoutine:
+        case .createRoutine, .updateRoutineCompletion:
                 .post
         case .fetchRoutine, .fetchRoutines:
                 .get
@@ -72,6 +75,8 @@ extension RoutineEndpoint: Endpoint {
             return routine.dictionary
         case .deleteDailyRoutine(let routine):
             return routine.dictionary
+        case .updateRoutineCompletion(let routines):
+            return routines.dictionary
         default:
             return [:]
         }

--- a/Projects/DataSource/Sources/Repository/RoutineRepository.swift
+++ b/Projects/DataSource/Sources/Repository/RoutineRepository.swift
@@ -84,4 +84,21 @@ final class RoutineRepository: RoutineRepositoryProtocol {
         let endpoint = RoutineEndpoint.deleteDailyRoutine(routine: deleteRoutineDTO)
         _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
     }
+
+    func updateRoutineCompletions(routines: [RoutineCompletionEntity]) async throws {
+        guard let routine = routines.first else { return }
+        let performedDate = routine.performedDate
+        let completionDTO = routines.map({ RoutineCompletionDTO(
+            routineId: $0.routineId,
+            completeYn: $0.completeYn,
+            historySeq: $0.historySeq,
+            routineType: $0.routineType) })
+
+        let completionListDTO = RoutineCompletionListDTO(
+            performedDate: performedDate,
+            routineCompletionInfos: completionDTO)
+
+        let endpoint = RoutineEndpoint.updateRoutineCompletion(routines: completionListDTO)
+        _ = try await networkService.request(endpoint: endpoint, type: EmptyResponseDTO.self)
+    }
 }

--- a/Projects/Domain/Sources/Entity/RoutineCompletionEntity.swift
+++ b/Projects/Domain/Sources/Entity/RoutineCompletionEntity.swift
@@ -1,0 +1,28 @@
+//
+//  RoutineCompletionEntity.swift
+//  Domain
+//
+//  Created by 최정인 on 8/6/25.
+//
+
+public struct RoutineCompletionEntity {
+    public let performedDate: String
+    public let routineId: String
+    public let completeYn: Bool
+    public let historySeq: Int
+    public let routineType: String
+
+    public init(
+        performedDate: String,
+        routineId: String,
+        completeYn: Bool,
+        historySeq: Int,
+        routineType: String
+    ) {
+        self.performedDate = performedDate
+        self.routineId = routineId
+        self.completeYn = completeYn
+        self.historySeq = historySeq
+        self.routineType = routineType
+    }
+}

--- a/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/RoutineRepositoryProtocol.swift
@@ -37,4 +37,8 @@ public protocol RoutineRepositoryProtocol {
     /// 당일 루틴을 삭제합니다.
     /// - Parameter routine: 삭제할 루틴 정보
     func deleteDailyRoutine(routine: DeleteRoutineEntity) async throws
+
+    /// 루틴 완료 여부를 업데이트 합니다.
+    /// - Parameter routines: 완료 여부를 업데이트할 루틴 배열
+    func updateRoutineCompletions(routines: [RoutineCompletionEntity]) async throws
 }

--- a/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
@@ -21,4 +21,6 @@ public protocol RoutineUseCaseProtocol {
     func deleteAllRoutine(routineId: String) async throws
 
     func deleteDailyRoutine(routine: DeleteRoutineEntity) async throws
+
+    func updateRoutineCompletion(routines: [RoutineCompletionEntity]) async throws
 }

--- a/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
@@ -78,4 +78,8 @@ public final class RoutineUseCase: RoutineUseCaseProtocol {
     public func deleteDailyRoutine(routine: DeleteRoutineEntity) async throws {
         try await routineRepository.deleteDailyRoutine(routine: routine)
     }
+
+    public func updateRoutineCompletion(routines: [RoutineCompletionEntity]) async throws {
+        try await routineRepository.updateRoutineCompletions(routines: routines)
+    }
 }

--- a/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
+++ b/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
@@ -49,7 +49,10 @@ public struct PresentationDependencyAssembler: DependencyAssemblerProtocol {
             guard let recommendedRoutineUseCase = container.resolve(type: RecommendedRoutineUseCaseProtocol.self)
             else { fatalError("recommendedRoutineUseCase 의존성이 등록되지 않았습니다.") }
 
-            return RecommendedRoutineViewModel(recommendedRoutineUseCase: recommendedRoutineUseCase)
+            guard let emotionRepository = container.resolve(type: EmotionRepositoryProtocol.self)
+            else { fatalError("emotionRepository 의존성이 등록되지 않았습니다.") }
+
+            return RecommendedRoutineViewModel(recommendedRoutineUseCase: recommendedRoutineUseCase, emotionRepository: emotionRepository)
         }
 
         DIContainer.shared.register(type: MypageViewModel.self) { container in

--- a/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
+++ b/Projects/Presentation/Sources/Home/Model/MainRoutine.swift
@@ -8,7 +8,7 @@
 import Domain
 import Foundation
 
-struct MainRoutine {
+struct MainRoutine: Routine {
     let id: String
     let title: String
     var isDone: Bool

--- a/Projects/Presentation/Sources/Home/Model/Routine.swift
+++ b/Projects/Presentation/Sources/Home/Model/Routine.swift
@@ -1,0 +1,13 @@
+//
+//  Routine.swift
+//  Presentation
+//
+//  Created by 최정인 on 8/6/25.
+//
+
+protocol Routine {
+    var id: String { get }
+    var isDone: Bool { get }
+    var routineType: String { get }
+    var historySeq: Int { get }
+}

--- a/Projects/Presentation/Sources/Home/Model/SubRoutine.swift
+++ b/Projects/Presentation/Sources/Home/Model/SubRoutine.swift
@@ -7,12 +7,14 @@
 
 import Domain
 
-struct SubRoutine: Hashable {
+struct SubRoutine: Hashable, Routine {
     let id: String
     let title: String
     var isDone: Bool
     let sortIndex: Int
     let completionId: Int?
+    let routineType: String
+    let historySeq: Int
 }
 
 extension SubRoutineEntity {
@@ -24,6 +26,8 @@ extension SubRoutineEntity {
             title: subRoutineName,
             isDone: completeYn,
             sortIndex: sortOrder,
-            completionId: routineCompletionId)
+            completionId: routineCompletionId,
+            routineType: routineType,
+            historySeq: historySeq)
     }
 }

--- a/Projects/Presentation/Sources/Home/View/Component/MainRoutineView.swift
+++ b/Projects/Presentation/Sources/Home/View/Component/MainRoutineView.swift
@@ -75,7 +75,7 @@ final class MainRoutineView: UIView {
         checkBackgroundView.layer.cornerRadius = Layout.checkBoxCornerRadius
 
         checkIcon.image = BitnagilIcon.checkIcon
-        checkIcon.tintColor = BitnagilColor.navy50
+        checkIcon.tintColor = mainRoutine.isDone ? BitnagilColor.navy500 : BitnagilColor.navy50
 
         moreButton.setImage(BitnagilIcon.ellipsisIcon, for: .normal)
         moreButton.addAction(UIAction { [weak self] _ in

--- a/Projects/Presentation/Sources/Home/View/Component/RoutineView.swift
+++ b/Projects/Presentation/Sources/Home/View/Component/RoutineView.swift
@@ -156,6 +156,9 @@ final class RoutineView: UIView {
 
     func updateMainRoutineState(isDone: Bool) {
         mainRoutineView.updateState(isDone: isDone)
+        for subRoutine in routine.subRoutines {
+            updateSubRoutineState(subRoutine: subRoutine, isDone: isDone)
+        }
     }
 
     func updateSubRoutineState(subRoutine: SubRoutine, isDone: Bool) {
@@ -167,6 +170,12 @@ final class RoutineView: UIView {
         if let subRoutineView = subRoutineButtons[subRoutine.id] {
             subRoutineView.updateState(isDone: isDone)
         }
+        checkSubRoutines()
+    }
+
+    func checkSubRoutines() {
+        let isDoneAllSubRoutines = routine.subRoutines.filter({ $0.isDone }).count == routine.subRoutines.count
+        mainRoutineView.updateState(isDone: isDoneAllSubRoutines)
     }
 }
 

--- a/Projects/Presentation/Sources/Home/View/Component/WeekView.swift
+++ b/Projects/Presentation/Sources/Home/View/Component/WeekView.swift
@@ -137,12 +137,15 @@ final class WeekView: UIView {
             let isSelected = calendar.isDate(date, inSameDayAs: selectedDate)
             let isToday = calendar.isDate(date, inSameDayAs: today)
 
-            let dateView = DateView(date: date,
-                                    isSelected: isSelected,
-                                    isToday: isToday)
+            let dateView = DateView(
+                date: date,
+                isSelected: isSelected,
+                isToday: isToday)
+
             dateView.didTappedDateButton = { [weak self] date in
                 self?.selectDate(date: date)
             }
+            
             dateViews[date] = dateView
             dateStackView.addArrangedSubview(dateView)
             dateView.snp.makeConstraints { make in

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -31,6 +31,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
         static let weekViewHeight: CGFloat = 127
         static let routineSortButtonTrailingSpacing: CGFloat = 8
         static let routineSortButtonSize: CGFloat = 40
+        static let routineSortViewHeight: CGFloat = 192
         static let routineStackViewSpacing: CGFloat = 21
         static let routineStackViewTopSpacing: CGFloat = 23
         static let routineStackViewBottomSpacing: CGFloat = 100
@@ -323,7 +324,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] fetchRoutineResult in
                 if fetchRoutineResult {
-                    self?.viewModel.action(input: .selectDate(date: Date()))
+                    self?.viewModel.action(input: .refreshSelectedDateRoutine)
                 }
             }
             .store(in: &cancellables)
@@ -354,6 +355,15 @@ final class HomeView: BaseViewController<HomeViewModel> {
                 }
             }
             .store(in: &cancellables)
+
+        viewModel.output.updateRoutineCompletionResultPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isUpdateRoutineCompletion in
+                if isUpdateRoutineCompletion {
+                    self?.viewModel.action(input: .refreshSelectedDateRoutine)
+                }
+            }
+            .store(in: &cancellables)
     }
 
     // 홈 Graident 배경색을 설정합니다.
@@ -371,7 +381,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
         if !tooltipView.isHidden {
             hideTooltipView()
         }
-        presentCustomBottomSheet(contentViewController: routineSortView, maxHeight: 192)
+        presentCustomBottomSheet(contentViewController: routineSortView, maxHeight: Layout.routineSortViewHeight)
     }
 
     // 해당 날짜의 Routine View를 설정합니다. (없다면 EmptyView)
@@ -519,8 +529,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
 // MARK: RoutineViewDelegate
 extension HomeView: RoutineViewDelegate {
     func routineView(_ sender: RoutineView, didTapMainRoutineCheckButton mainRoutine: MainRoutine) {
-        sender.updateMainRoutineState(isDone: !mainRoutine.isDone)
-        // TODO: 메인 루틴 완료 버튼 체크의 서버 통신을 수행해야 합니다. (viewModel에 action 정의)
+        viewModel.action(input: .updateRoutineCompletion(routines: [mainRoutine]))
     }
 
     func routineView(_ sender: RoutineView, didTapMainRoutineMoreButton mainRoutine: MainRoutine) {
@@ -535,8 +544,7 @@ extension HomeView: RoutineViewDelegate {
     }
 
     func routineView(_ sender: RoutineView, didTapSubRoutineCheckButton subRoutine: SubRoutine) {
-        sender.updateSubRoutineState(subRoutine: subRoutine, isDone: !subRoutine.isDone)
-        // TODO: 서브 루틴 완료 버튼 체크의 서버 통신을 수행해야 합니다. (viewModel에 action 정의)
+        viewModel.action(input: .updateRoutineCompletion(routines: [subRoutine]))
     }
 }
 

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -577,7 +577,10 @@ extension HomeView: RoutineViewDelegate {
 // MARK: SelectableItemTableViewDelegate
 extension HomeView: SelectableItemTableViewDelegate {
     func selectableItemTableView<T: SelectableItem & CaseIterable & Equatable>(_ sender: SelectableItemTableView<T>, didSelectItem: T?) {
-        // TODO: 완료 · 미완료 루틴을 정렬해야 합니다.
+        guard let sortType = didSelectItem as? RoutineSortType?
+        else { return }
+
+        viewModel.action(input: .selectRoutineSortType(routineSortType: sortType))
     }
 }
 

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -554,7 +554,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
 extension HomeView: RoutineViewDelegate {
     func routineView(_ sender: RoutineView, didTapMainRoutineCheckButton mainRoutine: MainRoutine) {
         showIndicatorView()
-        viewModel.action(input: .updateRoutineCompletion(routines: [mainRoutine]))
+        viewModel.action(input: .updateRoutineCompletion(updatedRoutine: mainRoutine))
     }
 
     func routineView(_ sender: RoutineView, didTapMainRoutineMoreButton mainRoutine: MainRoutine) {
@@ -570,7 +570,7 @@ extension HomeView: RoutineViewDelegate {
 
     func routineView(_ sender: RoutineView, didTapSubRoutineCheckButton subRoutine: SubRoutine) {
         showIndicatorView()
-        viewModel.action(input: .updateRoutineCompletion(routines: [subRoutine]))
+        viewModel.action(input: .updateRoutineCompletion(updatedRoutine: subRoutine))
     }
 }
 

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -103,7 +103,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureNavigationBar(navigationStyle: .hidden)
-        viewModel.action(input: .fetchEmotion)
+        viewModel.action(input: .loadEmotion)
     }
 
     override func viewDidLayoutSubviews() {
@@ -323,7 +323,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] fetchRoutineResult in
                 if fetchRoutineResult {
-                    self?.viewModel.action(input: .fetchDailyRoutines(date: Date()))
+                    self?.viewModel.action(input: .selectDate(date: Date()))
                 }
             }
             .store(in: &cancellables)
@@ -350,7 +350,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
                     if self.isShowingDeleteAlertView {
                         self.toggleDeleteAlertView()
                     }
-                    viewModel.action(input: .fetchRoutines)
+                    viewModel.action(input: .refreshSelectedDateRoutine)
                 }
             }
             .store(in: &cancellables)
@@ -550,11 +550,11 @@ extension HomeView: SelectableItemTableViewDelegate {
 // MARK: WeekViewDelegate
 extension HomeView: WeekViewDelegate {
     func weekView(_ sender: WeekView, didMoveWeek weekStartDate: Date) {
-        viewModel.action(input: .fetchDailyRoutines(date: weekStartDate))
+        viewModel.action(input: .selectDate(date: weekStartDate))
     }
     
     func weekView(_ sender: WeekView, didSelectDate date: Date) {
-        viewModel.action(input: .fetchDailyRoutines(date: date))
+        viewModel.action(input: .selectDate(date: date))
     }
 }
 

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -81,6 +81,8 @@ final class HomeView: BaseViewController<HomeViewModel> {
     private var isShowingDeleteAlertView: Bool = false
     private let deleteAlertView = RoutineDeleteAlertView()
 
+    private let loadingIndicatorView = UIActivityIndicatorView(style: .large)
+
     private var contentViewTopConstraint: Constraint?
     private var cancellables: Set<AnyCancellable>
 
@@ -97,6 +99,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
         super.viewDidLoad()
         configureNavigationBar(navigationStyle: .hidden)
         configureGradientBackground()
+        showIndicatorView()
         viewModel.action(input: .loadNickname)
         viewModel.action(input: .fetchRoutines)
     }
@@ -193,6 +196,9 @@ final class HomeView: BaseViewController<HomeViewModel> {
 
         deleteAlertView.delegate = self
         deleteAlertView.isHidden = true
+
+        loadingIndicatorView.hidesWhenStopped = true
+        loadingIndicatorView.color = BitnagilColor.gray40
     }
 
     override func configureLayout() {
@@ -211,6 +217,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
         contentView.addSubview(routineScrollView)
         routineScrollView.addSubview(routineSortButton)
         routineScrollView.addSubview(routineStackView)
+        contentView.addSubview(loadingIndicatorView)
 
         view.addSubview(dimmedView)
         view.addSubview(floatingMenu)
@@ -310,6 +317,10 @@ final class HomeView: BaseViewController<HomeViewModel> {
             make.width.equalTo(Layout.deleteAlertViewWidth)
             make.height.equalTo(Layout.deleteAlertViewHeight)
         }
+
+        loadingIndicatorView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
     }
 
     override func bind() {
@@ -325,6 +336,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
             .sink { [weak self] fetchRoutineResult in
                 if fetchRoutineResult {
                     self?.viewModel.action(input: .refreshSelectedDateRoutine)
+                    self?.hideIndicatorView()
                 }
             }
             .store(in: &cancellables)
@@ -352,6 +364,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
                         self.toggleDeleteAlertView()
                     }
                     viewModel.action(input: .refreshSelectedDateRoutine)
+                    hideIndicatorView()
                 }
             }
             .store(in: &cancellables)
@@ -361,6 +374,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
             .sink { [weak self] isUpdateRoutineCompletion in
                 if isUpdateRoutineCompletion {
                     self?.viewModel.action(input: .refreshSelectedDateRoutine)
+                    self?.hideIndicatorView()
                 }
             }
             .store(in: &cancellables)
@@ -524,11 +538,22 @@ final class HomeView: BaseViewController<HomeViewModel> {
         informationButton.isSelected = false
         tooltipView.hideTooltip()
     }
+
+    private func showIndicatorView() {
+        loadingIndicatorView.startAnimating()
+        contentView.isUserInteractionEnabled = false
+    }
+
+    private func hideIndicatorView() {
+        loadingIndicatorView.stopAnimating()
+        contentView.isUserInteractionEnabled = true
+    }
 }
 
 // MARK: RoutineViewDelegate
 extension HomeView: RoutineViewDelegate {
     func routineView(_ sender: RoutineView, didTapMainRoutineCheckButton mainRoutine: MainRoutine) {
+        showIndicatorView()
         viewModel.action(input: .updateRoutineCompletion(routines: [mainRoutine]))
     }
 
@@ -544,6 +569,7 @@ extension HomeView: RoutineViewDelegate {
     }
 
     func routineView(_ sender: RoutineView, didTapSubRoutineCheckButton subRoutine: SubRoutine) {
+        showIndicatorView()
         viewModel.action(input: .updateRoutineCompletion(routines: [subRoutine]))
     }
 }
@@ -611,10 +637,12 @@ extension HomeView: RoutineDetailViewDelegate {
 // MARK: RoutineDeleteAlertViewDelegate
 extension HomeView: RoutineDeleteAlertViewDelegate {
     func routineDeleteAlertViewDidTapDeleteAllRoutine(_ sender: RoutineDeleteAlertView) {
+        showIndicatorView()
         viewModel.action(input: .deleteAllRoutine)
     }
     
     func routineDeleteAlertViewDidTapDeleteDailyRoutine(_ sender: RoutineDeleteAlertView) {
+        showIndicatorView()
         viewModel.action(input: .deleteDailyRoutine)
     }
 }

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -20,6 +20,7 @@ final class HomeViewModel: ViewModel {
         case deleteAllRoutine
         case updateRoutineCompletion(routines: [Routine])
         case refreshSelectedDateRoutine
+        case selectRoutineSortType(routineSortType: RoutineSortType?)
     }
 
     struct Output {
@@ -42,6 +43,7 @@ final class HomeViewModel: ViewModel {
     private let selectedRoutineSubject = CurrentValueSubject<MainRoutine?, Never>(nil)
     private let deleteRoutineResultSubject = PassthroughSubject<Bool, Never>()
     private let updateRoutineCompletionResultSubject = PassthroughSubject<Bool, Never>()
+    private let routineSortTypeSubject = CurrentValueSubject<RoutineSortType?, Never>(nil)
 
     private let calendar = Calendar.current
     private let today = Date()
@@ -98,6 +100,9 @@ final class HomeViewModel: ViewModel {
 
         case .refreshSelectedDateRoutine:
             fetchRoutines(for: selectedDateSubject.value)
+
+        case .selectRoutineSortType(let routineSortType):
+            sortRoutine(routineSortType: routineSortType)
         }
     }
 
@@ -221,6 +226,7 @@ final class HomeViewModel: ViewModel {
         }
     }
 
+    // 루틴의 완료 여부를 업데이트 합니다.
     private func updateRoutineCompletion(routines: [Routine]) {
         let performedDate = selectedDateSubject.value.convertToString(dateType: .yearMonthDate)
         var routineCompletionEntities: [RoutineCompletionEntity] = []
@@ -282,5 +288,20 @@ final class HomeViewModel: ViewModel {
                 updateRoutineCompletionResultSubject.send(false)
             }
         }
+    }
+
+    private func sortRoutine(routineSortType: RoutineSortType?) {
+        let dailyRoutines = routinesSubject.value
+        var sortedRoutines: [MainRoutine]
+        switch routineSortType {
+        case .complete:
+            sortedRoutines = dailyRoutines.sorted(by: { $0.isDone && !$1.isDone})
+        case .incomplete:
+            sortedRoutines = dailyRoutines.sorted(by: { !$0.isDone && $1.isDone})
+        case nil:
+            let dateKey = selectedDateSubject.value.convertToString(dateType: .yearMonthDate)
+            sortedRoutines = self.routines[dateKey] ?? []
+        }
+        routinesSubject.send(sortedRoutines)
     }
 }

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -18,7 +18,7 @@ final class HomeViewModel: ViewModel {
         case selectRoutine(routine: MainRoutine?)
         case deleteDailyRoutine
         case deleteAllRoutine
-        case updateRoutineCompletion(routines: [Routine])
+        case updateRoutineCompletion(updatedRoutine: Routine)
         case refreshSelectedDateRoutine
         case selectRoutineSortType(routineSortType: RoutineSortType?)
     }
@@ -95,8 +95,8 @@ final class HomeViewModel: ViewModel {
         case .deleteAllRoutine:
             deleteAllRoutine()
 
-        case .updateRoutineCompletion(let routines):
-            updateRoutineCompletion(routines: routines)
+        case .updateRoutineCompletion(let updatedRoutine):
+            updateRoutineCompletion(updatedRoutine: updatedRoutine)
 
         case .refreshSelectedDateRoutine:
             fetchRoutines(for: selectedDateSubject.value)
@@ -227,53 +227,51 @@ final class HomeViewModel: ViewModel {
     }
 
     // 루틴의 완료 여부를 업데이트 합니다.
-    private func updateRoutineCompletion(routines: [Routine]) {
+    private func updateRoutineCompletion(updatedRoutine: Routine) {
         let performedDate = selectedDateSubject.value.convertToString(dateType: .yearMonthDate)
         var routineCompletionEntities: [RoutineCompletionEntity] = []
 
-        for routine in routines {
-            let isDone = !routine.isDone
-            let routineCompletionEntity = RoutineCompletionEntity(
-                performedDate: performedDate,
-                routineId: routine.id,
-                completeYn: isDone,
-                historySeq: routine.historySeq,
-                routineType: routine.routineType)
-            routineCompletionEntities.append(routineCompletionEntity)
+        let isDone = !updatedRoutine.isDone
+        let routineCompletionEntity = RoutineCompletionEntity(
+            performedDate: performedDate,
+            routineId: updatedRoutine.id,
+            completeYn: isDone,
+            historySeq: updatedRoutine.historySeq,
+            routineType: updatedRoutine.routineType)
+        routineCompletionEntities.append(routineCompletionEntity)
 
-            // 메인 루틴이라면, 그 안의 세부 루틴 값도 업데이트
-            if let mainRoutine = routine as? MainRoutine {
-                for subRoutine in mainRoutine.subRoutines {
-                    guard subRoutine.isDone != isDone else { continue }
-                    let subRoutineCompletionEntity = RoutineCompletionEntity(
-                        performedDate: performedDate,
-                        routineId: subRoutine.id,
-                        completeYn: isDone,
-                        historySeq: subRoutine.historySeq,
-                        routineType: subRoutine.routineType)
-                    routineCompletionEntities.append(subRoutineCompletionEntity)
-                }
-            } else if let subRoutine = routine as? SubRoutine {
-                // 세부 루틴이라면, 세부 루틴의 완료 값을 확인하여 메인 루틴도 업데이트
-                let mainRoutines = routinesSubject.value
-                for mainRoutine in mainRoutines {
-                    if mainRoutine.subRoutines.contains(subRoutine) {
-                        let mainRoutineIsDone = mainRoutine.isDone
-                        var subRoutineCompleted: Bool
-                        if subRoutine.isDone {
-                            subRoutineCompleted = mainRoutine.subRoutines.filter({ $0.isDone }).count - 1 == mainRoutine.subRoutines.count
-                        } else {
-                            subRoutineCompleted = mainRoutine.subRoutines.filter({ $0.isDone }).count + 1 == mainRoutine.subRoutines.count
-                        }
-                        if subRoutineCompleted != mainRoutineIsDone {
-                            let mainRoutineCompletionEntity = RoutineCompletionEntity(
-                                performedDate: performedDate,
-                                routineId: mainRoutine.id,
-                                completeYn: subRoutineCompleted,
-                                historySeq: mainRoutine.historySeq,
-                                routineType: mainRoutine.routineType)
-                            routineCompletionEntities.append(mainRoutineCompletionEntity)
-                        }
+        // 메인 루틴이라면, 그 안의 세부 루틴 값도 업데이트
+        if let mainRoutine = updatedRoutine as? MainRoutine {
+            for subRoutine in mainRoutine.subRoutines {
+                guard subRoutine.isDone != isDone else { continue }
+                let subRoutineCompletionEntity = RoutineCompletionEntity(
+                    performedDate: performedDate,
+                    routineId: subRoutine.id,
+                    completeYn: isDone,
+                    historySeq: subRoutine.historySeq,
+                    routineType: subRoutine.routineType)
+                routineCompletionEntities.append(subRoutineCompletionEntity)
+            }
+        } else if let subRoutine = updatedRoutine as? SubRoutine {
+            // 세부 루틴이라면, 세부 루틴의 완료 값을 확인하여 메인 루틴도 업데이트
+            let mainRoutines = routinesSubject.value
+            for mainRoutine in mainRoutines {
+                if mainRoutine.subRoutines.contains(subRoutine) {
+                    let mainRoutineIsDone = mainRoutine.isDone
+                    var subRoutineCompleted: Bool
+                    if subRoutine.isDone {
+                        subRoutineCompleted = mainRoutine.subRoutines.filter({ $0.isDone }).count - 1 == mainRoutine.subRoutines.count
+                    } else {
+                        subRoutineCompleted = mainRoutine.subRoutines.filter({ $0.isDone }).count + 1 == mainRoutine.subRoutines.count
+                    }
+                    if subRoutineCompleted != mainRoutineIsDone {
+                        let mainRoutineCompletionEntity = RoutineCompletionEntity(
+                            performedDate: performedDate,
+                            routineId: mainRoutine.id,
+                            completeYn: subRoutineCompleted,
+                            historySeq: mainRoutine.historySeq,
+                            routineType: mainRoutine.routineType)
+                        routineCompletionEntities.append(mainRoutineCompletionEntity)
                     }
                 }
             }

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -18,6 +18,7 @@ final class HomeViewModel: ViewModel {
         case selectRoutine(routine: MainRoutine?)
         case deleteDailyRoutine
         case deleteAllRoutine
+        case updateRoutineCompletion(routines: [Routine])
         case refreshSelectedDateRoutine
     }
 
@@ -28,6 +29,7 @@ final class HomeViewModel: ViewModel {
         let fetchRoutineResultPublisher: AnyPublisher<Bool, Never>
         let routinesPublisher: AnyPublisher<[MainRoutine], Never>
         let deleteRoutineResultPublisher: AnyPublisher<Bool, Never>
+        let updateRoutineCompletionResultPublisher: AnyPublisher<Bool, Never>
     }
 
     private(set) var output: Output
@@ -39,6 +41,7 @@ final class HomeViewModel: ViewModel {
     private let routinesSubject = CurrentValueSubject<[MainRoutine], Never>([])
     private let selectedRoutineSubject = CurrentValueSubject<MainRoutine?, Never>(nil)
     private let deleteRoutineResultSubject = PassthroughSubject<Bool, Never>()
+    private let updateRoutineCompletionResultSubject = PassthroughSubject<Bool, Never>()
 
     private let calendar = Calendar.current
     private let today = Date()
@@ -62,7 +65,8 @@ final class HomeViewModel: ViewModel {
             selectedDatePublisher: selectedDateSubject.eraseToAnyPublisher(),
             fetchRoutineResultPublisher: fetchRoutineResultSubject.eraseToAnyPublisher(),
             routinesPublisher: routinesSubject.eraseToAnyPublisher(),
-            deleteRoutineResultPublisher: deleteRoutineResultSubject.eraseToAnyPublisher()
+            deleteRoutineResultPublisher: deleteRoutineResultSubject.eraseToAnyPublisher(),
+            updateRoutineCompletionResultPublisher: updateRoutineCompletionResultSubject.eraseToAnyPublisher()
         )
     }
 
@@ -89,8 +93,10 @@ final class HomeViewModel: ViewModel {
         case .deleteAllRoutine:
             deleteAllRoutine()
 
+        case .updateRoutineCompletion(let routines):
+            updateRoutineCompletion(routines: routines)
+
         case .refreshSelectedDateRoutine:
-            fetchRoutines()
             fetchRoutines(for: selectedDateSubject.value)
         }
     }
@@ -182,6 +188,7 @@ final class HomeViewModel: ViewModel {
                 try await routineUseCase.deleteAllRoutine(routineId: routineId)
                 selectedRoutineSubject.send(nil)
                 deleteRoutineResultSubject.send(true)
+                fetchRoutines()
             } catch {
                 deleteRoutineResultSubject.send(false)
             }
@@ -207,8 +214,72 @@ final class HomeViewModel: ViewModel {
             do {
                 try await routineUseCase.deleteDailyRoutine(routine: deleteRoutinEntity)
                 deleteRoutineResultSubject.send(true)
+                fetchRoutines()
             } catch {
                 deleteRoutineResultSubject.send(false)
+            }
+        }
+    }
+
+    private func updateRoutineCompletion(routines: [Routine]) {
+        let performedDate = selectedDateSubject.value.convertToString(dateType: .yearMonthDate)
+        var routineCompletionEntities: [RoutineCompletionEntity] = []
+
+        for routine in routines {
+            let isDone = !routine.isDone
+            let routineCompletionEntity = RoutineCompletionEntity(
+                performedDate: performedDate,
+                routineId: routine.id,
+                completeYn: isDone,
+                historySeq: routine.historySeq,
+                routineType: routine.routineType)
+            routineCompletionEntities.append(routineCompletionEntity)
+
+            // 메인 루틴이라면, 그 안의 세부 루틴 값도 업데이트
+            if let mainRoutine = routine as? MainRoutine {
+                for subRoutine in mainRoutine.subRoutines {
+                    guard subRoutine.isDone != isDone else { continue }
+                    let subRoutineCompletionEntity = RoutineCompletionEntity(
+                        performedDate: performedDate,
+                        routineId: subRoutine.id,
+                        completeYn: isDone,
+                        historySeq: subRoutine.historySeq,
+                        routineType: subRoutine.routineType)
+                    routineCompletionEntities.append(subRoutineCompletionEntity)
+                }
+            } else if let subRoutine = routine as? SubRoutine {
+                // 세부 루틴이라면, 세부 루틴의 완료 값을 확인하여 메인 루틴도 업데이트
+                let mainRoutines = routinesSubject.value
+                for mainRoutine in mainRoutines {
+                    if mainRoutine.subRoutines.contains(subRoutine) {
+                        let mainRoutineIsDone = mainRoutine.isDone
+                        var subRoutineCompleted: Bool
+                        if subRoutine.isDone {
+                            subRoutineCompleted = mainRoutine.subRoutines.filter({ $0.isDone }).count - 1 == mainRoutine.subRoutines.count
+                        } else {
+                            subRoutineCompleted = mainRoutine.subRoutines.filter({ $0.isDone }).count + 1 == mainRoutine.subRoutines.count
+                        }
+                        if subRoutineCompleted != mainRoutineIsDone {
+                            let mainRoutineCompletionEntity = RoutineCompletionEntity(
+                                performedDate: performedDate,
+                                routineId: mainRoutine.id,
+                                completeYn: subRoutineCompleted,
+                                historySeq: mainRoutine.historySeq,
+                                routineType: mainRoutine.routineType)
+                            routineCompletionEntities.append(mainRoutineCompletionEntity)
+                        }
+                    }
+                }
+            }
+        }
+
+        Task {
+            do {
+                try await routineUseCase.updateRoutineCompletion(routines: routineCompletionEntities)
+                updateRoutineCompletionResultSubject.send(true)
+                fetchRoutines()
+            } catch {
+                updateRoutineCompletionResultSubject.send(false)
             }
         }
     }

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -12,29 +12,32 @@ import Foundation
 final class HomeViewModel: ViewModel {
     enum Input {
         case loadNickname
+        case loadEmotion
+        case selectDate(date: Date)
         case fetchRoutines
-        case fetchDailyRoutines(date: Date)
-        case fetchEmotion
         case selectRoutine(routine: MainRoutine?)
         case deleteDailyRoutine
         case deleteAllRoutine
+        case refreshSelectedDateRoutine
     }
 
     struct Output {
         let nicknamePublisher: AnyPublisher<String, Never>
+        let emotionPublisher: AnyPublisher<Emotion?, Never>
+        let selectedDatePublisher: AnyPublisher<Date, Never>
         let fetchRoutineResultPublisher: AnyPublisher<Bool, Never>
         let routinesPublisher: AnyPublisher<[MainRoutine], Never>
-        let emotionPublisher: AnyPublisher<Emotion?, Never>
         let deleteRoutineResultPublisher: AnyPublisher<Bool, Never>
     }
 
     private(set) var output: Output
     private var routines: [String: [MainRoutine]] = [:]
     private let nicknameSubject = CurrentValueSubject<String, Never>("")
+    private let emotionSubject = CurrentValueSubject<Emotion?, Never>(nil)
+    private let selectedDateSubject = CurrentValueSubject<Date, Never>(.now)
     private let fetchRoutineResultSubject = PassthroughSubject<Bool, Never>()
     private let routinesSubject = CurrentValueSubject<[MainRoutine], Never>([])
     private let selectedRoutineSubject = CurrentValueSubject<MainRoutine?, Never>(nil)
-    private let emotionSubject = CurrentValueSubject<Emotion?, Never>(nil)
     private let deleteRoutineResultSubject = PassthroughSubject<Bool, Never>()
 
     private let calendar = Calendar.current
@@ -55,9 +58,10 @@ final class HomeViewModel: ViewModel {
         self.emotionUseCase = emotionUseCase
         self.output = Output(
             nicknamePublisher: nicknameSubject.eraseToAnyPublisher(),
+            emotionPublisher: emotionSubject.eraseToAnyPublisher(),
+            selectedDatePublisher: selectedDateSubject.eraseToAnyPublisher(),
             fetchRoutineResultPublisher: fetchRoutineResultSubject.eraseToAnyPublisher(),
             routinesPublisher: routinesSubject.eraseToAnyPublisher(),
-            emotionPublisher: emotionSubject.eraseToAnyPublisher(),
             deleteRoutineResultPublisher: deleteRoutineResultSubject.eraseToAnyPublisher()
         )
     }
@@ -67,14 +71,14 @@ final class HomeViewModel: ViewModel {
         case .loadNickname:
             loadNickname()
 
+        case .loadEmotion:
+            fetchEmotion()
+
+        case .selectDate(let date):
+            selectDate(date: date)
+
         case .fetchRoutines:
             fetchRoutines()
-
-        case .fetchDailyRoutines(let date):
-            fetchRoutines(for: date)
-
-        case .fetchEmotion:
-            fetchEmotion()
 
         case .selectRoutine(let routine):
             selectedRoutineSubject.send(routine)
@@ -84,9 +88,15 @@ final class HomeViewModel: ViewModel {
 
         case .deleteAllRoutine:
             deleteAllRoutine()
+
+        case .refreshSelectedDateRoutine:
+            fetchRoutines()
+            fetchRoutines(for: selectedDateSubject.value)
         }
     }
 
+    // MARK: - User 정보
+    // 유저 닉네임을 불러옵니다.
     private func loadNickname() {
         Task {
             do {
@@ -98,13 +108,28 @@ final class HomeViewModel: ViewModel {
         }
     }
 
+    // 감정 구슬을 불러옵니다.
+    private func fetchEmotion() {
+        Task {
+            do {
+                let emotionEntity = try await emotionUseCase.fetchEmotion(date: today)
+                let emotion = emotionEntity?.toEmotion()
+                emotionSubject.send(emotion)
+            } catch {
+
+            }
+        }
+    }
+
+    // MARK: - 루틴
+    // 루틴들을 불러옵니다. (처음에는 +-1 주, 그 이후에는 1주씩)
     private func fetchRoutines() {
         var startDate = oldestDate
         var endDate = latestDate
 
         if routines.isEmpty {
-            startDate = calculateDate(for: today, offset: -1)
-            endDate = calculateDate(for: today, offset: 1)
+            startDate = calendar.date(byAdding: .weekOfYear, value: -1, to: today) ?? today
+            endDate = calendar.date(byAdding: .weekOfYear, value: 1, to: today) ?? today
 
             oldestDate = startDate
             latestDate = endDate
@@ -123,6 +148,13 @@ final class HomeViewModel: ViewModel {
         }
     }
 
+    // 날짜를 선택하고 그 날에 해당하는 루틴을 불러옵니다.
+    private func selectDate(date: Date) {
+        selectedDateSubject.send(date)
+        fetchRoutines(for: date)
+    }
+
+    // 선택한 날의 루틴을 필터링하여 보여줍니다. (oldestDate, latestDate 업데이트)
     private func fetchRoutines(for date: Date) {
         if date <= oldestDate {
             oldestDate = calendar.date(byAdding: .weekOfYear, value: -1, to: date) ?? date
@@ -140,24 +172,7 @@ final class HomeViewModel: ViewModel {
         routinesSubject.send(dailyRoutines)
     }
 
-    private func fetchEmotion() {
-        Task {
-            do {
-                let emotionEntity = try await emotionUseCase.fetchEmotion(date: today)
-                let emotion = emotionEntity?.toEmotion()
-                emotionSubject.send(emotion)
-            } catch {
-
-            }
-        }
-    }
-
-    // 필요 시, 루틴 데이터를 불러옵니다. (+- 주)
-    private func calculateDate(for date: Date, offset week: Int) -> Date {
-        let endDate = calendar.date(byAdding: .weekOfYear, value: week, to: date) ?? date
-        return endDate
-    }
-
+    // 반복 루틴을 삭제합니다.
     private func deleteAllRoutine() {
         guard let routineId = selectedRoutineSubject.value?.id
         else { return }
@@ -173,6 +188,7 @@ final class HomeViewModel: ViewModel {
         }
     }
 
+    // 당일 루틴을 삭제합니다.
     private func deleteDailyRoutine() {
         guard let routine = selectedRoutineSubject.value
         else { return }
@@ -183,7 +199,7 @@ final class HomeViewModel: ViewModel {
             routineId: routine.id,
             routineCompletionId: routine.completionId,
             historySeq: routine.historySeq,
-            performedDate: today.convertToString(dateType: .yearMonthDate),
+            performedDate: selectedDateSubject.value.convertToString(dateType: .yearMonthDate),
             routineType: routine.routineType,
             subRoutineInfosForDelete: deleteSubRoutineEntity)
 

--- a/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineView.swift
+++ b/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineView.swift
@@ -45,6 +45,7 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
     private var recommendedRoutineCards: [Int: RecommendedRoutineCardView] = [:]
     private let registerEmotionButton = RegisterEmotionButton()
 
+    private var isExistEmotion: Bool = false
     private var isShowingFloatingMenu: Bool = false
     private let dimmedView = UIView()
     private let floatingButton = FloatingButton()
@@ -60,12 +61,13 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         viewModel.action(input: .fetchRecommendedRoutines)
+        viewModel.action(input: .loadEmotion)
     }
 
-    public override func configureAttribute() {
+    override func configureAttribute() {
         title = "추천 루틴"
         categoryView.delegate = self
 
@@ -110,7 +112,7 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
         dimmedView.addGestureRecognizer(tapGesture)
     }
 
-    public override func configureLayout() {
+    override func configureLayout() {
         let safeArea = view.safeAreaLayoutGuide
         view.backgroundColor = .systemBackground
 
@@ -179,7 +181,7 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
         }
     }
 
-    public override func bind() {
+    override func bind() {
         viewModel.output.selectedCategoryPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] selectedCategory in
@@ -194,8 +196,19 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
                 self?.fetchRecommendedRoutines(recommendedRoutines: recommendedRoutines)
             }
             .store(in: &cancellables)
+
+        viewModel.output.emotionExistPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isExistEmotion in
+                if isExistEmotion {
+                    self?.isExistEmotion = isExistEmotion
+                    self?.registerEmotionButton.isHidden = true
+                }
+            }
+            .store(in: &cancellables)
     }
 
+    // 추천 루틴 카드 View
     private func fetchRecommendedRoutines(recommendedRoutines: [RecommendedRoutine]) {
         recommendedRoutineStackView.arrangedSubviews.forEach { view in
             if view != registerEmotionButton {
@@ -216,6 +229,7 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
         }
     }
 
+    // Bottom Sheet(난이도 필터링)를 보여줍니다.
     private func showBottomSheet() {
         if isShowingFloatingMenu {
             toggleFloatingButton()
@@ -223,7 +237,13 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
         presentCustomBottomSheet(contentViewController: levelView, maxHeight: Layout.bottomSheetHeight)
     }
 
+    // 감정 등록 버튼을 보이거나 숨겨줍니다.
     private func showEmotionButton(isShowEmotionButton: Bool) {
+        guard !isExistEmotion else {
+            registerEmotionButton.isHidden = true
+            return
+        }
+        
         guard isShowEmotionButton else {
             registerEmotionButton.isHidden = true
             return
@@ -240,6 +260,7 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
         }
     }
 
+    // 플로팅 버튼을 토글합니다. (플로팅 버튼 동작 및 플로팅 메뉴 등장)
     private func toggleFloatingButton() {
         floatingButton.toggle()
         isShowingFloatingMenu.toggle()

--- a/Projects/Presentation/Sources/RecommendedRoutine/ViewModel/RecommendedRoutineViewModel.swift
+++ b/Projects/Presentation/Sources/RecommendedRoutine/ViewModel/RecommendedRoutineViewModel.swift
@@ -7,11 +7,13 @@
 
 import Combine
 import Domain
+import Foundation
 import Shared
 
 final class RecommendedRoutineViewModel: ViewModel {
     enum Input {
         case fetchRecommendedRoutines
+        case loadEmotion
         case selectCategory(selectedCategory: RoutineCategoryType)
         case selectLevel(selectedLevel: RoutineLevelType?)
     }
@@ -20,6 +22,7 @@ final class RecommendedRoutineViewModel: ViewModel {
         let selectedCategoryPublisher: AnyPublisher<RoutineCategoryType, Never>
         let selectedRoutineLevelPublisher: AnyPublisher<RoutineLevelType?, Never>
         let recommendedRoutinePublisher: AnyPublisher<[RecommendedRoutine], Never>
+        let emotionExistPublisher: AnyPublisher<Bool, Never>
     }
 
     private(set) var output: Output
@@ -27,14 +30,18 @@ final class RecommendedRoutineViewModel: ViewModel {
     private let selectedCategorySubject = CurrentValueSubject<RoutineCategoryType, Never>(.recommendation)
     private let selectedRoutineLevelSubject = CurrentValueSubject<RoutineLevelType?, Never>(nil)
     private let recommendedRoutineSubject = CurrentValueSubject<[RecommendedRoutine], Never>([])
+    private let emotionExistSubject = CurrentValueSubject<Bool, Never>(false)
 
     private let recommendedRoutineUseCase: RecommendedRoutineUseCaseProtocol
-    init(recommendedRoutineUseCase: RecommendedRoutineUseCaseProtocol) {
+    private let emotionRepository: EmotionRepositoryProtocol
+    init(recommendedRoutineUseCase: RecommendedRoutineUseCaseProtocol, emotionRepository: EmotionRepositoryProtocol) {
         self.recommendedRoutineUseCase = recommendedRoutineUseCase
+        self.emotionRepository = emotionRepository
         self.output = Output(
             selectedCategoryPublisher: selectedCategorySubject.eraseToAnyPublisher(),
             selectedRoutineLevelPublisher: selectedRoutineLevelSubject.eraseToAnyPublisher(),
-            recommendedRoutinePublisher: recommendedRoutineSubject.eraseToAnyPublisher()
+            recommendedRoutinePublisher: recommendedRoutineSubject.eraseToAnyPublisher(),
+            emotionExistPublisher: emotionExistSubject.eraseToAnyPublisher()
         )
     }
 
@@ -43,6 +50,9 @@ final class RecommendedRoutineViewModel: ViewModel {
         case .fetchRecommendedRoutines:
             fetchRecommendedRoutines()
 
+        case .loadEmotion:
+            loadEmotion()
+            
         case .selectCategory(let selectedCategory):
             selectCategory(selectedCategory: selectedCategory)
 
@@ -95,6 +105,22 @@ final class RecommendedRoutineViewModel: ViewModel {
             recommendedRoutineSubject.send(filteredByLevel)
         } else {
             recommendedRoutineSubject.send(filteredByCategory)
+        }
+    }
+
+    // 감정 구슬을 불러옵니다.
+    private func loadEmotion() {
+        Task {
+            do {
+                let emotionEntity = try await emotionRepository.fetchEmotion(date: Date().convertToString(dateType: .yearMonthDate))
+                if emotionEntity == nil {
+                    emotionExistSubject.send(false)
+                } else {
+                    emotionExistSubject.send(true)
+                }
+            } catch {
+
+            }
         }
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

루틴 완료 로직을 구현했어요 ~~

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://github.com/user-attachments/assets/b7886170-5da2-4447-8508-3af6ca6af51f



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- 감정 구슬 등록 시, 추천 루틴 화면에서 '감정 등록' 버튼 안보이도록 수정
- 루틴 완료 로직 구현
- 루틴 정렬 로직 구현


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

- 루틴 완료 (세부 루틴, 메인 루틴)
- 루틴 정렬



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

**1. 복잡한 완료 로직 🤯**     

일단 Routine 완료 처리는 메인 루틴이든, 서부 루틴이든 같은 형식으로 서버에게 요청을 보냅니다.    
따라서 Routine이라는 Protocol을 구현하고, MainRoutine, SubRoutine이 모두 해당 프로토콜을 채택하도록 하였습니다.    


`HomeViewModel`의 `updateRoutineCompletion` 함수를 보시면 매우매우매우 복잡하고 더럽습니다 ㅜㅜ    

- 우선 완료할 루틴으로 매개변수로 받은 루틴을 Entity로 변환합니다.  
- 만약 매개변수로 받은 루틴이 메인 루틴이라면, 메인 루틴 안에 있는 서브 루틴들도 완료 처리를 하기 위해 Entity로 변환합니다.
- 만약 매개변수로 받은 루틴이 서브 루틴이라면, 메인 루틴도 완료할지, 메인 루틴도 취소할지에 따라 메인 루틴도 Entity로 변환합니다.
- 그렇게 해서 업데이트 처리해야 할 루틴들을 배열에 담아 서버 통신을 합니다 ..

... 개선할 수 있다면 꼭 개선할게요 ..

<br>

**2. 루틴 완료 처리 + indicator view**

이어서 루틴 완료 처리에 대해 말씀 드리자면 .. **낙관적 업데이트**라는 개념이 있다고 하더라고요.

우선 UI부터 업데이트 한 후에 서버 통신 로직을 태우고, 만약 서버 통신에 실패한다면 다시 롤백하는 구조라고 합니다.   

하지만 ... 지금 단계에 그것을 학습하고 적용하기에 시간이 너무 빠듯하다고 생각하여, 전 바로 서버 통신을 하도록 구현했습니다. ㅜㅜ     

- 루틴 완료 업데이트 처리 > Indicator > 다시 루틴 데이터 서버에서 refresh > refresh 완료 시 indicator hide 후 update view

이것에 대해 어떻게 생각하시나요 ?? ㅜㅜ

<br>


**3. fetch 루틴 오류**     

현재 fetch에서 오류가 나는 경우가 종종 있어요 ㅠㅠ   
이 PR에서 원인을 잡고 처리하기에는 PR 단위가 커질 수 있다고 판단되어 꼭 원인 파악 후 오늘 안에 다른 PR로 올려볼게용 ...

<br>

**4. 루틴 등록 및 수정 이후 HomeView**

루틴 등록 이후에 HomeView로 돌아오는 코드가 구현되어 있지 않는 것 같습니다 !! 
만약 HomeView로 돌아온다면 그 때 다시 루틴을 fetch하는 로직이 필요합니다 !  

단순히 viewWillAppear에 fetch를 넣을지, 아님 notification center를 이용해 구독할지 .. 고민이 되네요 !! 
3번 수정하면서 구현해보겠습니다.   


그리고 추가적으로 루틴 수정을 누르면 루틴 등록 폼에 수정할 루틴들이 채워져야 한다고 생각하는데 ..
그것이 구현되어 있찌 않더라고요 ㅠㅠ !! 혹시 제가 해야 하는 영역일까요 ??

루틴 등록 혹은 수정 시에 placeholder나 폼이 채워져야 하는 경우는 다음과 같습니다.
- 홈 화면에서 루틴 선택 후 루틴 수정
- 추천 루틴 화면에서 루틴 선택
- 감정 등록 후 결과로 받은 추천 루틴을 선택하고 루틴 등록하기로 이동
 


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #T3-144


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 루틴 완료 상태를 일괄 업데이트하는 기능이 추가되었습니다.
  * 루틴 및 서브루틴의 완료 상태 동기화 및 표시가 개선되었습니다.
  * 홈 화면에 비동기 작업 진행 시 표시되는 로딩 인디케이터가 추가되었습니다.
  * 감정 기록 존재 여부를 확인하고, 감정 기록이 있을 경우 관련 버튼이 자동으로 숨겨집니다.
  * 루틴 정렬 기능이 추가되어 완료 여부에 따라 정렬할 수 있습니다.

* **버그 수정 및 개선**
  * 루틴 및 서브루틴 체크 시 완료 상태가 상호 연동되어 자동으로 반영됩니다.
  * 날짜 선택, 루틴 삭제 등 다양한 사용자 액션에 대한 처리 및 UI 반영이 더 직관적으로 개선되었습니다.

* **스타일 및 리팩터링**
  * 일부 UI 컴포넌트의 색상 및 속성 적용 방식이 조건부로 변경되어 가독성이 향상되었습니다.
  * 코드 구조 및 의존성 주입 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->