### PR TITLE
[Feat] 추천 루틴 등록하기 기능 추가

### DIFF
--- a/Projects/DataSource/Sources/Endpoint/RecommendedRoutineEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/RecommendedRoutineEndpoint.swift
@@ -6,6 +6,7 @@
 //
 
 enum RecommendedRoutineEndpoint {
+    case fetchRecommendedRoutine(id: Int)
     case fetchRecommendedRoutines
 }
 
@@ -16,7 +17,10 @@ extension RecommendedRoutineEndpoint: Endpoint {
     
     var path: String {
         switch self {
-        case .fetchRecommendedRoutines: baseURL
+        case .fetchRecommendedRoutines:
+            return baseURL
+        case .fetchRecommendedRoutine(let id):
+            return "\(baseURL)/\(id)"
         }
     }
     

--- a/Projects/DataSource/Sources/Repository/RecommendedRoutineRepository.swift
+++ b/Projects/DataSource/Sources/Repository/RecommendedRoutineRepository.swift
@@ -10,6 +10,15 @@ import Domain
 final class RecommendedRoutineRepository: RecommendedRoutineRepositoryProtocol {
     private let networkService = NetworkService.shared
 
+    func fetchRecommendedRoutine(id: Int) async throws -> RecommendedRoutineEntity? {
+        let endpoint = RecommendedRoutineEndpoint.fetchRecommendedRoutine(id: id)
+
+        guard let recommendedRoutineDTO = try await networkService.request(endpoint: endpoint, type: RecommendedRoutineDTO.self)
+        else { return nil }
+
+        return recommendedRoutineDTO.toRecommendedRoutineEntity()
+    }
+
     func fetchRecommendedRoutines() async throws -> [RecommendedRoutineEntity] {
         let endpoint = RecommendedRoutineEndpoint.fetchRecommendedRoutines
         guard let response = try await networkService.request(endpoint: endpoint, type: RecommendedRoutineDictionaryResponseDTO.self)

--- a/Projects/Domain/Sources/Protocol/Repository/RecommendedRoutineRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/RecommendedRoutineRepositoryProtocol.swift
@@ -8,6 +8,10 @@
 // 추천 루틴에 관련된 데이터를 가져오는 Repository
 public protocol RecommendedRoutineRepositoryProtocol {
     /// 추천 루틴 데이터를 가져옵니다.
+    /// - Returns: 추천 루틴 (단건)
+    func fetchRecommendedRoutine(id: Int) async throws -> RecommendedRoutineEntity?
+
+    /// 추천 루틴 데이터를 가져옵니다.
     /// - Returns: 추천 루틴 목록
     func fetchRecommendedRoutines() async throws -> [RecommendedRoutineEntity]
 }

--- a/Projects/Domain/Sources/Protocol/UseCase/RecommendedRoutineUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/UseCase/RecommendedRoutineUseCaseProtocol.swift
@@ -7,6 +7,10 @@
 
 public protocol RecommendedRoutineUseCaseProtocol {
     /// 추천 루틴 데이터를 가져옵니다.
+    /// - Returns: 추천 루틴 (단건)
+    func fetchRecommendedRoutine(id: Int) async throws -> RecommendedRoutineEntity?
+
+    /// 추천 루틴 데이터를 가져옵니다.
     /// - Returns: 추천 루틴 목록
     func fetchRecommendedRoutines() async throws -> [RecommendedRoutineEntity]
 }

--- a/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/UseCase/RoutineUseCaseProtocol.swift
@@ -22,5 +22,5 @@ public protocol RoutineUseCaseProtocol {
 
     func deleteDailyRoutine(routine: DeleteRoutineEntity) async throws
 
-    func updateRoutineCompletion(routines: [RoutineCompletionEntity]) async throws
+    func updateRoutineCompletions(routines: [RoutineCompletionEntity]) async throws
 }

--- a/Projects/Domain/Sources/UseCase/RecommendedRoutine/RecommendedRoutineUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/RecommendedRoutine/RecommendedRoutineUseCase.swift
@@ -12,6 +12,11 @@ public final class RecommendedRoutineUseCase: RecommendedRoutineUseCaseProtocol 
         self.recommendedRoutineRepository = recommendedRoutineRepository
     }
 
+    public func fetchRecommendedRoutine(id: Int) async throws -> RecommendedRoutineEntity? {
+        let recommendedRoutine = try await recommendedRoutineRepository.fetchRecommendedRoutine(id: id)
+        return recommendedRoutine
+    }
+
     public func fetchRecommendedRoutines() async throws -> [RecommendedRoutineEntity] {
         let recommendedRoutines = try await recommendedRoutineRepository.fetchRecommendedRoutines()
         return recommendedRoutines

--- a/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Routine/RoutineUseCase.swift
@@ -79,7 +79,7 @@ public final class RoutineUseCase: RoutineUseCaseProtocol {
         try await routineRepository.deleteDailyRoutine(routine: routine)
     }
 
-    public func updateRoutineCompletion(routines: [RoutineCompletionEntity]) async throws {
+    public func updateRoutineCompletions(routines: [RoutineCompletionEntity]) async throws {
         try await routineRepository.updateRoutineCompletions(routines: routines)
     }
 }

--- a/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
+++ b/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
@@ -75,7 +75,7 @@ public struct PresentationDependencyAssembler: DependencyAssemblerProtocol {
                 let recommendedRoutineUseCase = container.resolve(type: RecommendedRoutineUseCaseProtocol.self)
             else { fatalError("routineUseCase, resultRecommendedRoutineUseCase 의존성이 등록되지 않았습니다.") }
 
-            return RoutineCreationViewModel(routineUseCase: routineUseCase, recommenedRoutineUseCase: recommendedRoutineUseCase)
+            return RoutineCreationViewModel(routineUseCase: routineUseCase, recommenededRoutineUseCase: recommendedRoutineUseCase)
         }
 
         DIContainer.shared.register(type: ResultRecommendedRoutineViewModel.self) { container in

--- a/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
+++ b/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
@@ -70,10 +70,12 @@ public struct PresentationDependencyAssembler: DependencyAssemblerProtocol {
         }
 
         DIContainer.shared.register(type: RoutineCreationViewModel.self) { container in
-            guard let routineUseCase = container.resolve(type: RoutineUseCaseProtocol.self)
-            else { fatalError("routineUseCase 의존성이 등록되지 않았습니다.") }
+            guard
+                let routineUseCase = container.resolve(type: RoutineUseCaseProtocol.self),
+                let recommendedRoutineUseCase = container.resolve(type: RecommendedRoutineUseCaseProtocol.self)
+            else { fatalError("routineUseCase, resultRecommendedRoutineUseCase 의존성이 등록되지 않았습니다.") }
 
-            return RoutineCreationViewModel(routineUseCase: routineUseCase)
+            return RoutineCreationViewModel(routineUseCase: routineUseCase, recommenedRoutineUseCase: recommendedRoutineUseCase)
         }
 
         DIContainer.shared.register(type: ResultRecommendedRoutineViewModel.self) { container in

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -279,7 +279,7 @@ final class HomeViewModel: ViewModel {
 
         Task {
             do {
-                try await routineUseCase.updateRoutineCompletion(routines: routineCompletionEntities)
+                try await routineUseCase.updateRoutineCompletions(routines: routineCompletionEntities)
                 updateRoutineCompletionResultSubject.send(true)
                 fetchRoutines()
             } catch {

--- a/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineView.swift
+++ b/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineView.swift
@@ -289,7 +289,13 @@ extension RecommendedRoutineView: RoutineCategoryViewDelegate {
 // MARK: RecommendedRoutineCardViewDelegate
 extension RecommendedRoutineView: RecommendedRoutineCardViewDelegate {
     func recommendedRoutineCardView(_ sender: RecommendedRoutineCardView, didTapRecommendedRoutine routine: RecommendedRoutine) {
-        // TODO: 루틴 등록하기 화면으로 이동해야 함 + 추천 루틴 들고
+        guard let routineCreationViewModel = DIContainer.shared.resolve(type: RoutineCreationViewModel.self) else {
+            fatalError("routineCreationViewModel 의존성이 등록되지 않았습니다.")
+        }
+
+        let routineCreationView = RoutineCreationView(viewModel: routineCreationViewModel, recommendRoutineId: routine.id)
+        routineCreationView.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(routineCreationView, animated: true)
     }
 }
 

--- a/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationView.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationView.swift
@@ -93,7 +93,15 @@ final class RoutineCreationView: BaseViewController<RoutineCreationViewModel> {
             viewModel.action(input: .fetchRoutine(id: routineId))
         }
     }
-    
+
+    init(viewModel: RoutineCreationViewModel, recommendRoutineId: Int) {
+        navigationTitle = "루틴 등록"
+        registerButtonTitle = "등록하기"
+
+        super.init(viewModel: viewModel)
+        viewModel.action(input: .fetchRecommendedRoutine(id: recommendRoutineId))
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -527,6 +535,7 @@ final class RoutineCreationView: BaseViewController<RoutineCreationViewModel> {
         registerButton.addAction(
             UIAction { [weak self] _ in
                 self?.viewModel.action(input: .registerRoutine)
+                self?.navigationController?.popViewController(animated: true)
             },
             for: .touchUpInside)
     }

--- a/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
@@ -70,13 +70,13 @@ final class RoutineCreationViewModel: ViewModel {
     private let executionTimeSubject = CurrentValueSubject<ExecutionType, Never>(.none)
     private let checkRoutinePublisher = PassthroughSubject<Bool, Never>()
     private let routineUseCase: RoutineUseCaseProtocol
-    private let recommenedRoutineUseCase: RecommendedRoutineUseCaseProtocol
+    private let recommenededRoutineUseCase: RecommendedRoutineUseCaseProtocol
     private var deletedSubroutines = Set<SubRoutineSummaryEntity>()
     private var routineId: String?
 
-    init(routineUseCase: RoutineUseCaseProtocol, recommenedRoutineUseCase: RecommendedRoutineUseCaseProtocol) {
+    init(routineUseCase: RoutineUseCaseProtocol, recommenededRoutineUseCase: RecommendedRoutineUseCaseProtocol) {
         self.routineUseCase = routineUseCase
-        self.recommenedRoutineUseCase = recommenedRoutineUseCase
+        self.recommenededRoutineUseCase = recommenededRoutineUseCase
 
         output = Output(
             namePublisher: nameSubject.eraseToAnyPublisher(),
@@ -96,7 +96,7 @@ final class RoutineCreationViewModel: ViewModel {
         case .fetchRoutine(let id):
             fetchRoutine(id: id)
         case .fetchRecommendedRoutine(let id):
-            fetchRecommenedRoutine(id: id)
+            fetchRecommendedRoutine(id: id)
         case .configureName(let name):
             configureName(name: name)
         case .addSubRoutine:
@@ -157,10 +157,10 @@ final class RoutineCreationViewModel: ViewModel {
         }
     }
 
-    private func fetchRecommenedRoutine(id: Int) {
+    private func fetchRecommendedRoutine(id: Int) {
         Task {
             do {
-                guard let routine = try await recommenedRoutineUseCase.fetchRecommendedRoutine(id: id) else { return }
+                guard let routine = try await recommenededRoutineUseCase.fetchRecommendedRoutine(id: id) else { return }
 
                 let subRoutines = routine.subRoutines.map {
                     SubRoutineSummaryEntity(

--- a/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
@@ -41,6 +41,7 @@ final class RoutineCreationViewModel: ViewModel {
 
     enum Input {
         case fetchRoutine(id: String)
+        case fetchRecommendedRoutine(id: Int)
         case configureName(name: String)
         case addSubRoutine
         case deleteSubRoutine(index: Int)
@@ -69,11 +70,13 @@ final class RoutineCreationViewModel: ViewModel {
     private let executionTimeSubject = CurrentValueSubject<ExecutionType, Never>(.none)
     private let checkRoutinePublisher = PassthroughSubject<Bool, Never>()
     private let routineUseCase: RoutineUseCaseProtocol
+    private let recommenedRoutineUseCase: RecommendedRoutineUseCaseProtocol
     private var deletedSubroutines = Set<SubRoutineSummaryEntity>()
     private var routineId: String?
 
-    init(routineUseCase: RoutineUseCaseProtocol) {
+    init(routineUseCase: RoutineUseCaseProtocol, recommenedRoutineUseCase: RecommendedRoutineUseCaseProtocol) {
         self.routineUseCase = routineUseCase
+        self.recommenedRoutineUseCase = recommenedRoutineUseCase
 
         output = Output(
             namePublisher: nameSubject.eraseToAnyPublisher(),
@@ -92,6 +95,8 @@ final class RoutineCreationViewModel: ViewModel {
         switch input {
         case .fetchRoutine(let id):
             fetchRoutine(id: id)
+        case .fetchRecommendedRoutine(let id):
+            fetchRecommenedRoutine(id: id)
         case .configureName(let name):
             configureName(name: name)
         case .addSubRoutine:
@@ -148,6 +153,27 @@ final class RoutineCreationViewModel: ViewModel {
                 updateIsRoutineValid()
             } catch {
                 // TODO: - 요기도 마찬가지 (ViewModel 공통 todo)
+            }
+        }
+    }
+
+    private func fetchRecommenedRoutine(id: Int) {
+        Task {
+            do {
+                guard let routine = try await recommenedRoutineUseCase.fetchRecommendedRoutine(id: id) else { return }
+
+                let subRoutines = routine.subRoutines.map {
+                    SubRoutineSummaryEntity(
+                        subRoutineId: nil,
+                        subRoutineName: $0.title,
+                        sortOrder: nil)
+                }
+
+                nameSubject.send(routine.title)
+                subRoutinesSubject.send(subRoutines)
+
+                updateIsRoutineValid()
+            } catch {
             }
         }
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 루틴 등록/수정 시 뒤로 가지 못하는 치명적인 문제를 고쳐야 했습니다..
- 더불어 인지하지 못했던 추천 루틴 추가 기능을 붙였습니다!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
| iPhone SE3 | iPhone 13 mini | iPhone 16 Pro |
|:----------:|:--------------:|:-------------:|
| ![se3](https://github.com/user-attachments/assets/cc8ba309-d424-43e6-8b75-7179ff0b9073) | ![13mini](https://github.com/user-attachments/assets/3b16ceb0-8a48-4408-8fa1-c1cde69f79bd) | ![16pro](https://github.com/user-attachments/assets/1eae87d7-6890-4d39-8627-845446d84183) |

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 루틴 등록/수정 완료 후 뒤로 가기 기능 추가
- 추천 루틴 선택 시 루틴 등록 화면으로 이동하도록 함

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황

- 시나리오 진행에 필요한 값

- 시나리오 진행에 필요한 조건

- 시나리오 완료 시 보장하는 결과


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 추천 루틴 조회 (단건)을 RecommenedRoutine 관련 객체에 구현했습니다. (usecase, repository, endpoint)
- 일단 급한대로, 잘 구현해두신 RecommendedRoutine 관련 객체들을 사용했습니다!! 조금 아쉬웠던 점은, RecommendedRoutine과 Routine을 통일해서 쓸 수 있다면 좋을것 같다는 생각이 들었습니다! response를 내려줄 때 최대한 통일해서 주면 훨씬 깔끔한 구조로 리팩터링이 가능하지 않을까요?? 서버 분들과 관련해서 이야기 나눠보면 좋을 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 추천 루틴을 ID로 조회하여 루틴 등록 화면에서 불러올 수 있는 기능이 추가되었습니다.
  * 추천 루틴 카드 선택 시, 해당 루틴을 기반으로 루틴 등록 화면으로 이동합니다.
  * 루틴 등록 화면에서 추천 루틴의 제목과 하위 루틴 정보가 자동으로 입력됩니다.

* **개선 사항**
  * 루틴 등록 완료 시, 등록 화면이 자동으로 닫히도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->