### PR TITLE
[Feat] 토스트 메시지 뷰 구현 

### DIFF
--- a/Projects/Presentation/Sources/Common/Component/ToastMessageView.swift
+++ b/Projects/Presentation/Sources/Common/Component/ToastMessageView.swift
@@ -1,0 +1,123 @@
+//
+//  ToastMessageView.swift
+//  Presentation
+//
+//  Created by 이동현 on 8/7/25.
+//
+
+import SnapKit
+import UIKit
+
+public final class ToastMessageView: UIView {
+    private enum Layout {
+        static let checkImageViewSize: CGFloat = 24
+        static let checkImageViewLeadingSpace: CGFloat = 16
+        static let checkImageViewTrailingSpace: CGFloat = 4
+        static let labelHorizontalSpace: CGFloat = 20
+        static let verticalSpace: CGFloat = 10
+        static let height: CGFloat = 44
+        static let width: CGFloat = 200
+    }
+
+    private let checkImageView = UIImageView()
+    private let label = UILabel()
+    private var labelLeadingConstraint: Constraint?
+    private var heightConstraint: Constraint?
+    private var widthConstraint: Constraint?
+
+    init() {
+        super.init(frame: .zero)
+        configureAttribute()
+        configureLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureAttribute() {
+        self.alpha = 0
+        self.isHidden = true
+
+        backgroundColor = BitnagilColor.navy400
+        layer.cornerRadius = 8
+        layer.masksToBounds = true
+
+        checkImageView.image = BitnagilIcon.checkIcon?.withRenderingMode(.alwaysTemplate)
+        checkImageView.tintColor = BitnagilColor.orange500
+
+        label.font = BitnagilFont.init(style: .body2, weight: .medium).font
+        label.textColor = .white
+        label.textAlignment = .center
+        label.numberOfLines = 0
+    }
+
+    private func configureLayout() {
+        addSubview(checkImageView)
+        addSubview(label)
+
+        checkImageView.snp.makeConstraints { make in
+            make.size.equalTo(Layout.checkImageViewSize)
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().offset(Layout.checkImageViewLeadingSpace)
+        }
+
+        label.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-Layout.labelHorizontalSpace)
+            make.verticalEdges.equalToSuperview().inset(Layout.verticalSpace)
+            labelLeadingConstraint = make
+                .leading
+                .equalToSuperview()
+                .offset(Layout.labelHorizontalSpace)
+                .constraint
+        }
+
+        snp.makeConstraints { make in
+            heightConstraint = make
+                .height
+                .equalTo(Layout.height)
+                .constraint
+            widthConstraint = make
+                .width
+                .equalTo(Layout.width)
+                .constraint
+        }
+    }
+
+    func showToast(
+        withCheckImage: Bool,
+        message: String,
+        width: CGFloat,
+        height: CGFloat
+    ) {
+        guard isHidden else { return }
+
+        label.text = message
+        checkImageView.isHidden = !withCheckImage
+
+        let labelLeadingSpacing = withCheckImage
+            ? Layout.checkImageViewLeadingSpace + Layout.checkImageViewSize + Layout.checkImageViewTrailingSpace
+            : Layout.labelHorizontalSpace
+
+        labelLeadingConstraint?.update(offset: labelLeadingSpacing)
+        heightConstraint?.update(offset: height)
+        widthConstraint?.update(offset: width + 10)
+
+        self.alpha = 0
+        self.isHidden = false
+
+        UIView.animate(withDuration: 0.35, delay: 0.01) {
+            self.alpha = 1
+        } completion: { [weak self] _ in
+            self?.hideToast()
+        }
+    }
+
+    private func hideToast() {
+        UIView.animate(withDuration: 0.35, delay: 3.2) {
+            self.alpha = 0
+        } completion: { _ in
+            self.isHidden = true
+        }
+    }
+}

--- a/Projects/Presentation/Sources/Common/Protocol/BaseViewController.swift
+++ b/Projects/Presentation/Sources/Common/Protocol/BaseViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 최정인 on 6/26/25.
 //
 
+import SnapKit
 import UIKit
 
 public class BaseViewController<T: ViewModel>: UIViewController {

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -53,6 +53,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
         static let routineDetailViewSubRoutineHeight: CGFloat = 25
         static let deleteAlertViewWidth: CGFloat = 298
         static let deleteAlertViewHeight: CGFloat = 214
+        static let toastMessageBottomSpacing: CGFloat = 19
     }
 
     private let gradientLayer = CAGradientLayer()
@@ -70,6 +71,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
     private let routineSortView = SelectableItemTableView<RoutineSortType>(items: [RoutineSortType.complete, RoutineSortType.incomplete])
     private let routineStackView = UIStackView()
 
+    private let toastMessageView = ToastMessageView()
     private let tooltipView = TooltipView(tailPosition: .offsetFromLeading(Layout.tooltipViewTailLeadingSpacing))
 
     private var isShowingFloatingMenu: Bool = false
@@ -224,6 +226,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
         view.addSubview(floatingButton)
 
         view.addSubview(deleteAlertView)
+        view.addSubview(toastMessageView)
 
         homeLabel.snp.makeConstraints { make in
             make.top.equalTo(safeArea).offset(Layout.homeLabelTopSpacing)
@@ -320,6 +323,11 @@ final class HomeView: BaseViewController<HomeViewModel> {
 
         loadingIndicatorView.snp.makeConstraints { make in
             make.center.equalToSuperview()
+        }
+
+        toastMessageView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(safeArea.snp.bottom).offset(-Layout.toastMessageBottomSpacing)
         }
     }
 
@@ -431,7 +439,12 @@ final class HomeView: BaseViewController<HomeViewModel> {
         }
         emotionOrbView.kf.setImage(with: emotionOrbImageUrl)
         registerEmotionButton.isEnabled = false
-        // TODO: 토스트뷰 보여주기
+
+        toastMessageView.showToast(
+            withCheckImage: true,
+            message: "선택한 감정 구슬이 이미 반영되었어요.",
+            width: 265,
+            height: 44)
     }
 
     @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {

--- a/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineView.swift
+++ b/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineView.swift
@@ -32,6 +32,7 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
         static let floatingMenuBottomSpacing: CGFloat = 15
         static let floatingMenuHeight: CGFloat = 64
         static let floatingMenuWidth: CGFloat = 144
+        static let toastMessageBottomSpacing: CGFloat = 19
     }
 
     private let categoryView = RoutineCategoryView()
@@ -50,6 +51,8 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
     private let dimmedView = UIView()
     private let floatingButton = FloatingButton()
     private let floatingMenu = FloatingMenuView()
+
+    private let toastMessageView = ToastMessageView()
 
     private var cancellables: Set<AnyCancellable>
     public override init(viewModel: RecommendedRoutineViewModel) {
@@ -128,6 +131,8 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
         view.addSubview(floatingMenu)
         view.addSubview(floatingButton)
 
+        view.addSubview(toastMessageView)
+
         categoryView.snp.makeConstraints { make in
             make.leading.equalTo(safeArea)
             make.trailing.equalTo(safeArea)
@@ -178,6 +183,11 @@ final class RecommendedRoutineView: BaseViewController<RecommendedRoutineViewMod
 
         dimmedView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+
+        toastMessageView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(safeArea.snp.bottom).offset(-Layout.toastMessageBottomSpacing)
         }
     }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 토스트 메시지 뷰 구현

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
| iPhone SE3 | iPhone 13 mini | iPhone 16 Pro |
|:---:|:---:|:---:|
| ![se3](https://github.com/user-attachments/assets/bf251723-ea9e-4637-b6ba-cf2c00208826) | ![13nmini](https://github.com/user-attachments/assets/3adf249c-1632-4d61-b1d2-0317e73b9e5d) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-08 at 00 13 04](https://github.com/user-attachments/assets/2a55dd22-3c83-40e8-998b-ee507d8807e0) |

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
### 사용 방법
1. 사용할 View에 ToastMessageView를 추가합니다.
2. 다음과 같이 layout을 잡아줍니다. 
```swift
        toastMessageView.snp.makeConstraints { make in
            make.centerX.equalToSuperview()
            make.bottom.equalTo(safeArea.snp.bottom).offset(-Layout.toastMessageBottomSpacing)
        }
```
3. 사용 시, 체크이미지 여부, 메시지, 너비와 높이를 지정합니다.
```swift 
toastMessageView.showToast(
            withCheckImage: true,
            message: "선택한 감정 구슬이 이미 반영되었어요.",
            width: 265,
            height: 44)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 토스트 메시지 UI가 추가되어, 사용자에게 안내 메시지를 화면 하단에 표시할 수 있습니다.
  * Home 화면에서 이미 적용된 감정 오브를 선택하면 토스트 메시지로 안내가 표시됩니다.
  * 추천 루틴 화면에도 토스트 메시지 컴포넌트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->