### PR TITLE
[Fix] 토큰 재발급 role 추가

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -58,8 +58,9 @@ extension SceneDelegate: SplashViewDelegate {
         else { fatalError("onboardingRepository 의존성이 등록되지 않았습니다.") }
 
         Task { @MainActor in
-            let isLogined = await userDataRepository.reissueToken()
-            if isLogined {
+            let userState = await userDataRepository.reissueToken()
+            switch userState {
+            case .user:
                 if onboardingRepository.isOnboardingDone() {
                     window?.rootViewController = TabBarView()
                 } else {
@@ -70,7 +71,7 @@ extension SceneDelegate: SplashViewDelegate {
                     let navigationController = UINavigationController(rootViewController: onboardingView)
                     window?.rootViewController = navigationController
                 }
-            } else {
+            case .guest, nil:
                 let introView = IntroView()
                 let navigationController = UINavigationController(rootViewController: introView)
                 window?.rootViewController = navigationController

--- a/Projects/DataSource/Sources/Repository/UserDataRepository.swift
+++ b/Projects/DataSource/Sources/Repository/UserDataRepository.swift
@@ -22,24 +22,26 @@ final class UserDataRepository: UserDataRepositoryProtocol {
         return user.nickname
     }
 
-    func reissueToken() async -> Bool {
+    func reissueToken() async -> UserState? {
         do {
             let refreshToken = try tokenManager.loadToken(tokenType: .refreshToken)
             let endpoint = AuthEndpoint.reissue(refreshToken: refreshToken)
 
-            guard let tokenResponse = try await networkService.request(endpoint: endpoint, type: TokenResponseDTO.self)
-            else { return false }
+            guard let loginResponse = try await networkService.request(endpoint: endpoint, type: LoginResponseDTO.self)
+            else { return nil }
 
-            try tokenManager.saveToken(token: tokenResponse.accessToken, tokenType: .accessToken)
-            try tokenManager.saveToken(token: tokenResponse.refreshToken, tokenType: .refreshToken)
+            try tokenManager.saveToken(token: loginResponse.accessToken, tokenType: .accessToken)
+            try tokenManager.saveToken(token: loginResponse.refreshToken, tokenType: .refreshToken)
 
-            BitnagilLogger.log(logType: .debug, message: "AccessToken Saved: \(tokenResponse.accessToken)")
-            BitnagilLogger.log(logType: .debug, message: "RefreshToken Saved: \(tokenResponse.refreshToken)")
+            BitnagilLogger.log(logType: .debug, message: "AccessToken Saved: \(loginResponse.accessToken)")
+            BitnagilLogger.log(logType: .debug, message: "RefreshToken Saved: \(loginResponse.refreshToken)")
+            BitnagilLogger.log(logType: .debug, message: "User State: \(loginResponse.userState)")
 
-            return true
+            let userState = UserState(rawValue: loginResponse.userState)
+            return userState
         } catch {
             BitnagilLogger.log(logType: .error, message: "\(error.localizedDescription)")
-            return false
+            return nil
         }
     }
 }

--- a/Projects/Domain/Sources/Protocol/Repository/UserDataRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/UserDataRepositoryProtocol.swift
@@ -12,5 +12,5 @@ public protocol UserDataRepositoryProtocol {
     func loadNickname() async throws -> String
 
     /// 토큰 재발급을 진행합니다.
-    func reissueToken() async -> Bool
+    func reissueToken() async -> UserState?
 }

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -137,12 +137,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
         }, for: .touchUpInside)
 
         let registerEmotionAction = UIAction(identifier: registerEmotionButtonActionIdentifier) { [weak self] _ in
-            guard let emotionRegisterViewModel = DIContainer.shared.resolve(type: EmotionRegisterViewModel.self) else {
-                fatalError("emotionRegisterViewModel 의존성이 등록되지 않았습니다.")
-            }
-            let emotionRegisterView = EmotionRegisterView(viewModel: emotionRegisterViewModel)
-            emotionRegisterView.hidesBottomBarWhenPushed = true
-            self?.navigationController?.pushViewController(emotionRegisterView, animated: true)
+            self?.goToEmotionRegisterView()
         }
         registerEmotionButton.addAction(registerEmotionAction, for: .touchUpInside)
 
@@ -439,6 +434,10 @@ final class HomeView: BaseViewController<HomeViewModel> {
         guard
             let emotion,
             let emotionOrbImageUrl = emotion.emotionImageUrl else {
+            let registerEmotionAction = UIAction(identifier: registerEmotionButtonActionIdentifier) { [weak self] _ in
+                self?.goToEmotionRegisterView()
+            }
+            registerEmotionButton.addAction(registerEmotionAction, for: .touchUpInside)
             emotionOrbView.image = BitnagilGraphic.defaultEmotionGraphic
             return
         }
@@ -568,6 +567,15 @@ final class HomeView: BaseViewController<HomeViewModel> {
     private func hideIndicatorView() {
         loadingIndicatorView.stopAnimating()
         contentView.isUserInteractionEnabled = true
+    }
+
+    private func goToEmotionRegisterView() {
+        guard let emotionRegisterViewModel = DIContainer.shared.resolve(type: EmotionRegisterViewModel.self) else {
+            fatalError("emotionRegisterViewModel 의존성이 등록되지 않았습니다.")
+        }
+        let emotionRegisterView = EmotionRegisterView(viewModel: emotionRegisterViewModel)
+        emotionRegisterView.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(emotionRegisterView, animated: true)
     }
 }
 

--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -54,12 +54,15 @@ final class HomeView: BaseViewController<HomeViewModel> {
         static let deleteAlertViewWidth: CGFloat = 298
         static let deleteAlertViewHeight: CGFloat = 214
         static let toastMessageBottomSpacing: CGFloat = 19
+        static let toastMessageWidth: CGFloat = 265
+        static let toastMessageHeight: CGFloat = 44
     }
 
     private let gradientLayer = CAGradientLayer()
     private let homeLabel = UILabel()
     private let informationButton = UIButton()
     private let emotionOrbView = UIImageView()
+    private let registerEmotionButtonActionIdentifier = UIAction.Identifier("goToEmotionRegisterView")
     private let registerEmotionButton = HomeRegisterEmotionButton()
 
     private let contentView = UIView()
@@ -133,14 +136,15 @@ final class HomeView: BaseViewController<HomeViewModel> {
             }
         }, for: .touchUpInside)
 
-        registerEmotionButton.addAction(UIAction { [weak self] _ in
+        let registerEmotionAction = UIAction(identifier: registerEmotionButtonActionIdentifier) { [weak self] _ in
             guard let emotionRegisterViewModel = DIContainer.shared.resolve(type: EmotionRegisterViewModel.self) else {
                 fatalError("emotionRegisterViewModel 의존성이 등록되지 않았습니다.")
             }
             let emotionRegisterView = EmotionRegisterView(viewModel: emotionRegisterViewModel)
             emotionRegisterView.hidesBottomBarWhenPushed = true
             self?.navigationController?.pushViewController(emotionRegisterView, animated: true)
-        }, for: .touchUpInside)
+        }
+        registerEmotionButton.addAction(registerEmotionAction, for: .touchUpInside)
 
         contentView.backgroundColor = .white
         contentView.layer.cornerRadius = Layout.contentViewCornerRadius
@@ -344,8 +348,8 @@ final class HomeView: BaseViewController<HomeViewModel> {
             .sink { [weak self] fetchRoutineResult in
                 if fetchRoutineResult {
                     self?.viewModel.action(input: .refreshSelectedDateRoutine)
-                    self?.hideIndicatorView()
                 }
+                self?.hideIndicatorView()
             }
             .store(in: &cancellables)
 
@@ -353,6 +357,7 @@ final class HomeView: BaseViewController<HomeViewModel> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] routines in
                 self?.updateRoutineView(routines: routines)
+                self?.hideIndicatorView()
             }
             .store(in: &cancellables)
 
@@ -438,13 +443,16 @@ final class HomeView: BaseViewController<HomeViewModel> {
             return
         }
         emotionOrbView.kf.setImage(with: emotionOrbImageUrl)
-        registerEmotionButton.isEnabled = false
-
-        toastMessageView.showToast(
-            withCheckImage: true,
-            message: "선택한 감정 구슬이 이미 반영되었어요.",
-            width: 265,
-            height: 44)
+        registerEmotionButton.removeAction(identifiedBy: registerEmotionButtonActionIdentifier, for: .touchUpInside)
+        registerEmotionButton.addAction(
+            UIAction { [weak self] _ in
+                self?.toastMessageView.showToast(
+                    withCheckImage: true,
+                    message: "선택한 감정 구슬이 이미 반영되었어요.",
+                    width: Layout.toastMessageWidth,
+                    height: Layout.toastMessageHeight)
+            },
+            for: .touchUpInside)
     }
 
     @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineView.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineView.swift
@@ -360,7 +360,7 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
                 tabBarView.selectedIndex = 2
             }
         case .emotion:
-            viewModel.action(input: .fetchSelectedRoutinId)
+            viewModel.action(input: .fetchSelectedRoutineId)
         }
     }
 

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineView.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineView.swift
@@ -261,6 +261,14 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
                 }
             }
             .store(in: &cancellables)
+
+        viewModel.output.selectedRoutineIdPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] routineId in
+                guard let routineId else { return }
+                self?.goToRoutineCreationView(routineId: routineId)
+            }
+            .store(in: &cancellables)
     }
 
     // 추천 루틴 뷰들을 업데이트합니다.
@@ -352,10 +360,14 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
                 tabBarView.selectedIndex = 2
             }
         case .emotion:
-            guard let routineCreationViewModel = DIContainer.shared.resolve(type: RoutineCreationViewModel.self)
-            else { fatalError("routineCreationViewModel 의존성이 등록되지 않았습니다.") }
-            let routineCreationView = RoutineCreationView(viewModel: routineCreationViewModel)
-            self.navigationController?.pushViewController(routineCreationView, animated: true)
+            viewModel.action(input: .fetchSelectedRoutinId)
         }
+    }
+
+    private func goToRoutineCreationView(routineId: Int) {
+        guard let routineCreationViewModel = DIContainer.shared.resolve(type: RoutineCreationViewModel.self)
+        else { fatalError("routineCreationViewModel 의존성이 등록되지 않았습니다.") }
+        let routineCreationView = RoutineCreationView(viewModel: routineCreationViewModel, recommendRoutineId: routineId)
+        self.navigationController?.pushViewController(routineCreationView, animated: true)
     }
 }

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
@@ -19,12 +19,14 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
     
     enum Input {
         case fetchResultRecommendedRoutines
+        case fetchSelectedRoutinId
         case selectRecommendedRoutine(routine: RecommendedRoutine)
         case registerRecommendedRoutine
     }
 
     struct Output {
         let resultRecommendedRoutinesPublisher: AnyPublisher<[RecommendedRoutine], Never>
+        let selectedRoutineIdPublisher: AnyPublisher<Int?, Never>
         let selectedRecommendedRoutinePublisher: AnyPublisher<Set<RecommendedRoutine>, Never>
         let confirmButtonPublisher: AnyPublisher<Bool, Never>
         let registerRoutineResultPublisher: AnyPublisher<Bool, Never>
@@ -32,6 +34,7 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
 
     private(set) var output: Output
     private let resultRecommendedRoutinesSubject = CurrentValueSubject<[RecommendedRoutine], Never>([])
+    private let selectedRoutinIdSubject = PassthroughSubject<Int?, Never>()
     private let selectedRecommendedRoutineSubject = CurrentValueSubject<Set<RecommendedRoutine>, Never>([])
     private let confirmButtonSubject = PassthroughSubject<Bool, Never>()
     private let registerRoutineResultSubject = PassthroughSubject<Bool, Never>()
@@ -42,6 +45,7 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
         self.resultRecommendedRoutineUseCase = resultRecommendedRoutineUseCase
         output = Output(
             resultRecommendedRoutinesPublisher: resultRecommendedRoutinesSubject.eraseToAnyPublisher(),
+            selectedRoutineIdPublisher: selectedRoutinIdSubject.eraseToAnyPublisher(),
             selectedRecommendedRoutinePublisher: selectedRecommendedRoutineSubject.eraseToAnyPublisher(),
             confirmButtonPublisher: confirmButtonSubject.eraseToAnyPublisher(),
             registerRoutineResultPublisher: registerRoutineResultSubject.eraseToAnyPublisher()
@@ -52,6 +56,10 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
         switch input {
         case .fetchResultRecommendedRoutines:
             fetchResultRecommendedRoutines()
+
+        case .fetchSelectedRoutinId:
+            let routineId = selectedRecommendedRoutineSubject.value.first?.id
+            selectedRoutinIdSubject.send(routineId)
 
         case .selectRecommendedRoutine(let routine):
             selectRecommendedRoutine(routine: routine)

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
@@ -19,7 +19,7 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
     
     enum Input {
         case fetchResultRecommendedRoutines
-        case fetchSelectedRoutinId
+        case fetchSelectedRoutineId
         case selectRecommendedRoutine(routine: RecommendedRoutine)
         case registerRecommendedRoutine
     }
@@ -34,7 +34,7 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
 
     private(set) var output: Output
     private let resultRecommendedRoutinesSubject = CurrentValueSubject<[RecommendedRoutine], Never>([])
-    private let selectedRoutinIdSubject = PassthroughSubject<Int?, Never>()
+    private let selectedRoutineIdSubject = PassthroughSubject<Int?, Never>()
     private let selectedRecommendedRoutineSubject = CurrentValueSubject<Set<RecommendedRoutine>, Never>([])
     private let confirmButtonSubject = PassthroughSubject<Bool, Never>()
     private let registerRoutineResultSubject = PassthroughSubject<Bool, Never>()
@@ -45,7 +45,7 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
         self.resultRecommendedRoutineUseCase = resultRecommendedRoutineUseCase
         output = Output(
             resultRecommendedRoutinesPublisher: resultRecommendedRoutinesSubject.eraseToAnyPublisher(),
-            selectedRoutineIdPublisher: selectedRoutinIdSubject.eraseToAnyPublisher(),
+            selectedRoutineIdPublisher: selectedRoutineIdSubject.eraseToAnyPublisher(),
             selectedRecommendedRoutinePublisher: selectedRecommendedRoutineSubject.eraseToAnyPublisher(),
             confirmButtonPublisher: confirmButtonSubject.eraseToAnyPublisher(),
             registerRoutineResultPublisher: registerRoutineResultSubject.eraseToAnyPublisher()
@@ -57,9 +57,9 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
         case .fetchResultRecommendedRoutines:
             fetchResultRecommendedRoutines()
 
-        case .fetchSelectedRoutinId:
+        case .fetchSelectedRoutineId:
             let routineId = selectedRecommendedRoutineSubject.value.first?.id
-            selectedRoutinIdSubject.send(routineId)
+            selectedRoutineIdSubject.send(routineId)
 
         case .selectRecommendedRoutine(let routine):
             selectRecommendedRoutine(routine: routine)

--- a/SupportingFiles/Info.plist
+++ b/SupportingFiles/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>0.0.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

- 토큰 재발급에서 Response로 받은 role을 통해 guest vs user를 구분합니다.
- 만약 guest 라면 Home 진입이 아닌 Intro 화면을 통해 다시 로그인을 하도록 유도합니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- 토큰 재발급 role 분기 처리 추가
- Home 화면에서 감정 구슬 버튼 클릭 시, 이미 감정 구슬이 등록되었다면 토스트 메시지 뷰 뜨도록 수정
- 감정 구슬 등록 후 추천 루틴을 선택 후 루틴 등록 화면으로 이동할 시에 추천 루틴 Id 넘겨주도록 수정




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 추천 루틴 결과 화면에서 선택된 루틴의 ID를 비동기적으로 받아와 루틴 생성 화면으로 이동하는 기능이 추가되었습니다.
  * ViewModel에 선택된 루틴 ID를 발행하는 publisher가 추가되었습니다.
  * 홈 화면에서 감정 등록 버튼의 동작이 UIAction을 활용해 구조화되었습니다.

* **버그 수정**
  * 홈 화면에서 감정 등록 버튼의 토스트 메시지 표시 동작이 개선되었습니다.

* **기타**
  * 로그인 상태 판별이 기존의 단순 로그인 여부에서 사용자, 게스트, 미확인 상태로 세분화되어 처리됩니다.
  * 앱 버전이 0.0.3으로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->