### PR TITLE
[Fix] 루틴 불러오는 로직 수정

### DIFF
--- a/Projects/Presentation/Sources/Home/View/HomeView.swift
+++ b/Projects/Presentation/Sources/Home/View/HomeView.swift
@@ -106,13 +106,13 @@ final class HomeView: BaseViewController<HomeViewModel> {
         configureGradientBackground()
         showIndicatorView()
         viewModel.action(input: .loadNickname)
-        viewModel.action(input: .fetchRoutines)
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureNavigationBar(navigationStyle: .hidden)
         viewModel.action(input: .loadEmotion)
+        viewModel.action(input: .fetchRoutines)
     }
 
     override func viewDidLayoutSubviews() {

--- a/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Home/ViewModel/HomeViewModel.swift
@@ -99,7 +99,7 @@ final class HomeViewModel: ViewModel {
             updateRoutineCompletion(updatedRoutine: updatedRoutine)
 
         case .refreshSelectedDateRoutine:
-            fetchRoutines(for: selectedDateSubject.value)
+            fetchDailyRoutine(for: selectedDateSubject.value)
 
         case .selectRoutineSortType(let routineSortType):
             sortRoutine(routineSortType: routineSortType)
@@ -135,17 +135,51 @@ final class HomeViewModel: ViewModel {
     // MARK: - 루틴
     // 루틴들을 불러옵니다. (처음에는 +-1 주, 그 이후에는 1주씩)
     private func fetchRoutines() {
-        var startDate = oldestDate
-        var endDate = latestDate
-
         if routines.isEmpty {
-            startDate = calendar.date(byAdding: .weekOfYear, value: -1, to: today) ?? today
-            endDate = calendar.date(byAdding: .weekOfYear, value: 1, to: today) ?? today
+            oldestDate = calendar.date(byAdding: .weekOfYear, value: -1, to: today) ?? today
+            latestDate = calendar.date(byAdding: .weekOfYear, value: 1, to: today) ?? today
+        }
+        fetchRoutines(startDate: oldestDate, endDate: latestDate)
+    }
 
-            oldestDate = startDate
-            latestDate = endDate
+    // 날짜를 선택하고 그 날에 해당하는 루틴을 불러옵니다.
+    private func selectDate(date: Date) {
+        selectedDateSubject.send(date)
+        fetchRoutines()
+        fetchDailyRoutine(for: date)
+    }
+
+    private func fetchDailyRoutine(for date: Date) {
+        if let dailyRoutines = routines[date.convertToString(dateType: .yearMonthDate)] {
+            routinesSubject.send(dailyRoutines)
+            return
         }
 
+        var startDate: Date = Date()
+        var endDate: Date = Date()
+        if date < oldestDate {
+            // 캐싱된 데이터보다 이전의 날짜 조회 시,
+            startDate = calendar.date(byAdding: .weekOfYear, value: -1, to: oldestDate) ?? oldestDate
+            endDate = calendar.date(byAdding: .day, value: -1, to: oldestDate) ?? oldestDate
+            oldestDate = startDate
+        } else if date > latestDate {
+            // 캐싱된 데이터보다 이후의 날짜 조회 시,
+            startDate = calendar.date(byAdding: .day, value: 1, to: latestDate) ?? latestDate
+            endDate = calendar.date(byAdding: .weekOfYear, value: 1, to: latestDate) ?? latestDate
+            latestDate = endDate
+        }
+        fetchRoutines(startDate: startDate, endDate: endDate)
+
+        if let dailyRoutines = routines[date.convertToString(dateType: .yearMonthDate)] {
+            routinesSubject.send(dailyRoutines)
+            return
+        } else {
+            routinesSubject.send([])
+        }
+    }
+
+    // 서버로부터 루틴들을 불러옵니다.. (루틴 조회 시작 날짜 ~ 루틴 조회 종료 날짜)
+    private func fetchRoutines(startDate: Date, endDate: Date) {
         Task {
             do {
                 let entities = try await routineUseCase.fetchRoutines(startDate: startDate, endDate: endDate)
@@ -154,33 +188,9 @@ final class HomeViewModel: ViewModel {
                 }
                 fetchRoutineResultSubject.send(true)
             } catch {
-
+                // TODO: 에러 처리
             }
         }
-    }
-
-    // 날짜를 선택하고 그 날에 해당하는 루틴을 불러옵니다.
-    private func selectDate(date: Date) {
-        selectedDateSubject.send(date)
-        fetchRoutines(for: date)
-    }
-
-    // 선택한 날의 루틴을 필터링하여 보여줍니다. (oldestDate, latestDate 업데이트)
-    private func fetchRoutines(for date: Date) {
-        if date <= oldestDate {
-            oldestDate = calendar.date(byAdding: .weekOfYear, value: -1, to: date) ?? date
-            latestDate = calendar.date(byAdding: .day, value: -1, to: date) ?? date
-        } else if date >= latestDate {
-            oldestDate = calendar.date(byAdding: .day, value: 1, to: date) ?? date
-            latestDate = calendar.date(byAdding: .weekOfYear, value: 1, to: date) ?? date
-        }
-
-        let dateKey = date.convertToString(dateType: .yearMonthDate)
-        guard let dailyRoutines = routines[dateKey] else {
-            fetchRoutines()
-            return
-        }
-        routinesSubject.send(dailyRoutines)
     }
 
     // 반복 루틴을 삭제합니다.

--- a/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineView.swift
+++ b/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineView.swift
@@ -327,6 +327,7 @@ extension RecommendedRoutineView: FloatingMenuViewDelegate {
             fatalError("routineCreationViewModel 의존성이 등록되지 않았습니다.")
         }
         let routineCreationView = RoutineCreationView(viewModel: routineCreationViewModel)
+        routineCreationView.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(routineCreationView, animated: true)
     }
 }

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineView.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineView.swift
@@ -368,6 +368,7 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
         guard let routineCreationViewModel = DIContainer.shared.resolve(type: RoutineCreationViewModel.self)
         else { fatalError("routineCreationViewModel 의존성이 등록되지 않았습니다.") }
         let routineCreationView = RoutineCreationView(viewModel: routineCreationViewModel, recommendRoutineId: routineId)
+        routineCreationView.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(routineCreationView, animated: true)
     }
 }

--- a/Projects/Presentation/Sources/RoutineCreation/View/Component/RoutineCreationInputView.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/View/Component/RoutineCreationInputView.swift
@@ -48,6 +48,7 @@ final class RoutineCreationInputView: UIView {
         textField.delegate = self
         textField.textColor = .black
         textField.font = BitnagilFont.init(style: .body2, weight: .semiBold).font
+        textField.returnKeyType = .done
 
         deleteButton.setImage(BitnagilIcon.deleteIcon, for: .normal)
         deleteButton.addAction(
@@ -100,6 +101,11 @@ extension RoutineCreationInputView: UITextFieldDelegate {
         if let text = textField.text {
             delegate?.routineCreationInputView(self, didChangeText: text)
         }
+        return true
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
         return true
     }
 }

--- a/Projects/Presentation/Sources/RoutineCreation/View/Component/RoutineCreationInputView.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/View/Component/RoutineCreationInputView.swift
@@ -49,6 +49,7 @@ final class RoutineCreationInputView: UIView {
         textField.textColor = .black
         textField.font = BitnagilFont.init(style: .body2, weight: .semiBold).font
         textField.returnKeyType = .done
+        textField.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingChanged)
 
         deleteButton.setImage(BitnagilIcon.deleteIcon, for: .normal)
         deleteButton.addAction(
@@ -94,16 +95,13 @@ final class RoutineCreationInputView: UIView {
     func configure(title: String) {
         textField.text = title
     }
+
+    @objc private func textFieldEditingChanged(_ sender: UITextField) {
+        delegate?.routineCreationInputView(self, didChangeText: sender.text ?? "")
+    }
 }
 
 extension RoutineCreationInputView: UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if let text = textField.text {
-            delegate?.routineCreationInputView(self, didChangeText: text)
-        }
-        return true
-    }
-
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true

--- a/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationView.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationView.swift
@@ -621,6 +621,8 @@ final class RoutineCreationView: BaseViewController<RoutineCreationViewModel> {
             repeatInfoButton.isSelected = false
             repeatToolTipView.hideTooltip()
         }
+
+        view.endEditing(true)
     }
 }
 

--- a/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
@@ -272,12 +272,7 @@ final class RoutineCreationViewModel: ViewModel {
         guard
             let name = nameSubject.value,
             !name.isEmpty,
-            executionTimeSubject.value != .none,
-            weekDaySubject.value.count > 0,
-            subRoutinesSubject
-                .value
-                .map({$0.subRoutineName})
-                .allSatisfy({$0?.isEmpty == false })
+            executionTimeSubject.value != .none
         else {
             checkRoutinePublisher.send(false)
             return

--- a/SupportingFiles/Info.plist
+++ b/SupportingFiles/Info.plist
@@ -62,5 +62,7 @@
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

루틴 불러오기가 무한루프를 탔던 이슈를 해결했시유 ㅠㅠ !!!!!!!!!!!! 
뇌를 조금 식혀주니까 돌아가긴 했는데. ... 아직 완벽하게 맘에 들지는 않아요 ㅠㅠ     



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- 루틴 fetch 로직 수정
- 루틴 등록하기 View에서 키보드 내려가기 동작 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 루틴 생성 입력란에서 키보드의 완료(Return) 키를 누르면 키보드가 자동으로 닫히도록 개선되었습니다.
  * 루틴 생성 화면에서 정보 버튼이나 툴팁 외의 영역을 탭하면 키보드가 자동으로 닫히도록 변경되었습니다.

* **기능 개선**
  * 홈 화면 진입 시마다 루틴 목록이 새로고침되어 항상 최신 정보를 확인할 수 있습니다.
  * 홈 화면의 루틴 데이터 조회가 날짜별로 더 효율적으로 캐시되고 관리되도록 개선되었습니다.
  * 추천 루틴 화면에서 루틴 생성 화면으로 이동 시 하단 탭 바가 숨겨지도록 변경되었습니다.

* **기타**
  * iOS 기기에서 앱이 전체 화면 모드로 실행되도록 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->