### PR TITLE
[FIX] 루틴 등록/수정 로직 수정

### DIFF
--- a/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationViewController.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationViewController.swift
@@ -108,9 +108,14 @@ final class RoutineCreationViewController: BaseViewController<RoutineCreationVie
         let attributes: [NSAttributedString.Key: Any] = [
             .font: BitnagilFont(style: .title3, weight: .semiBold).font,
             .foregroundColor: BitnagilColor.gray90 ?? .systemGray]
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        tap.delegate = self
 
         view.backgroundColor = .white
+        view.addGestureRecognizer(tap)
 
+        scrollView.keyboardDismissMode = .interactive
         nameTextField.attributedPlaceholder = NSAttributedString(string: "루틴 제목을 입력해주세요.", attributes: attributes)
         nameTextField.font = BitnagilFont(style: .title3, weight: .semiBold).font
         nameTextField.textColor = BitnagilColor.gray10
@@ -132,6 +137,7 @@ final class RoutineCreationViewController: BaseViewController<RoutineCreationVie
         registerButton.addAction(
             UIAction { [weak self] _ in
                 self?.viewModel.action(input: .registerRoutine)
+                self?.navigationController?.popViewController(animated: true)
             },
             for: .touchUpInside)
         bindCreationCardViews()
@@ -335,6 +341,10 @@ final class RoutineCreationViewController: BaseViewController<RoutineCreationVie
         }
     }
 
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+
     @objc private func textFieldEditingChanged(_ sender: UITextField) {
         viewModel.action(input: .configureName(name: sender.text ?? ""))
     }
@@ -365,5 +375,11 @@ extension RoutineCreationViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
+    }
+}
+
+extension RoutineCreationViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        return !(touch.view is UIControl)
     }
 }

--- a/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
@@ -46,12 +46,12 @@ final class RoutineCreationViewModel: ViewModel {
 
     private(set) var output: Output
     private let nameSubject = CurrentValueSubject<String?, Never>("")
-    private let subRoutinesSubject = CurrentValueSubject<[String], Never>([])
+    private let subRoutinesSubject = CurrentValueSubject<[String], Never>(["", "", ""])
     private let repeatTypeSubject = CurrentValueSubject<RepeatType?, Never>(nil)
     private let periodStartSubject = CurrentValueSubject<Date?, Never>(nil)
     private let periodEndSubject   = CurrentValueSubject<Date?, Never>(nil)
     private let executionTimeSubject = CurrentValueSubject<ExecutionTime, Never>(.init(startAt: nil))
-    private let checkRoutinePublisher = PassthroughSubject<Bool, Never>()
+    private let checkRoutinePublisher = CurrentValueSubject<Bool, Never>(false)
     private let routineUseCase: RoutineUseCaseProtocol
     private let recommenededRoutineUseCase: RecommendedRoutineUseCaseProtocol
     private var deletedSubroutines = Set<SubRoutineSummaryEntity>()
@@ -62,7 +62,7 @@ final class RoutineCreationViewModel: ViewModel {
     init(routineUseCase: RoutineUseCaseProtocol, recommenededRoutineUseCase: RecommendedRoutineUseCaseProtocol) {
         self.routineUseCase = routineUseCase
         self.recommenededRoutineUseCase = recommenededRoutineUseCase
-
+        
         output = Output(
             namePublisher: nameSubject.eraseToAnyPublisher(),
             subRoutinesPublisher: subRoutinesSubject.eraseToAnyPublisher(),
@@ -75,6 +75,8 @@ final class RoutineCreationViewModel: ViewModel {
                 .map { $0.startAt }
                 .eraseToAnyPublisher(),
             isRoutineValid: checkRoutinePublisher.eraseToAnyPublisher())
+        
+        updateIsRoutineValid()
     }
 
     func action(input: Input) {


### PR DESCRIPTION
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 서브 루틴이 정상적으로 등록/수정되도록 함
- 루틴 등록 시 이전 화면으로 이동

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 키보드 영역 밖을 누르면 키보드가 내려가는 로직 부분이 미흡합니다.
- 루틴 등록을 위한 각 cardView를 탭할 때 키보드가 내려가지 않는 문제가 있습니다. 빠르게 시정하겠습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 입력 영역 밖을 탭하면 키보드가 내려가며, 스크롤 제스처로도 부드럽게 닫힙니다.
  * 버튼 등 UI 컨트롤의 터치는 제스처에 방해받지 않도록 안전하게 동작합니다.
  * 루틴 등록 완료 후 이전 화면으로 자동 이동합니다.
  * 루틴 생성 시 기본 하위 항목 3개가 미리 제공되어 즉시 편집할 수 있습니다.
  * 초기 유효성 상태가 즉시 반영되어 유효성 표시가 더 일관됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->