### PR TITLE
[Feat-T3-183] 온보딩 · 목표 재설정 api v2 연동

### DIFF
--- a/Projects/DataSource/Sources/DTO/OnboardingDTO.swift
+++ b/Projects/DataSource/Sources/DTO/OnboardingDTO.swift
@@ -1,0 +1,22 @@
+//
+//  OnboardingDTO.swift
+//  DataSource
+//
+//  Created by 최정인 on 8/27/25.
+//
+
+import Domain
+
+struct OnboardingDTO: Encodable {
+    let timeSlot: String
+    let emotionType: [String]
+    let realOutingFrequency: String?
+    let targetOutingFrequency: String
+
+    func toOnboardingEntity() -> OnboardingEntity {
+        return OnboardingEntity(
+            time: timeSlot,
+            feeling: emotionType,
+            outdoor: targetOutingFrequency)
+    }
+}

--- a/Projects/DataSource/Sources/DTO/OnboardingDTO.swift
+++ b/Projects/DataSource/Sources/DTO/OnboardingDTO.swift
@@ -17,6 +17,7 @@ struct OnboardingDTO: Encodable {
         return OnboardingEntity(
             time: timeSlot,
             feeling: emotionType,
+            frequency: realOutingFrequency,
             outdoor: targetOutingFrequency)
     }
 }

--- a/Projects/DataSource/Sources/DTO/OnboardingResponseDTO.swift
+++ b/Projects/DataSource/Sources/DTO/OnboardingResponseDTO.swift
@@ -1,0 +1,21 @@
+//
+//  OnboardingResponseDTO.swift
+//  DataSource
+//
+//  Created by 최정인 on 9/1/25.
+//
+
+import Domain
+
+struct OnboardingResponseDTO: Decodable {
+    let timeSlot: String
+    let emotionTypes: [String]
+    let targetOutingFrequency: String
+
+    func toOnboardingEntity() -> OnboardingEntity {
+        return OnboardingEntity(
+            time: timeSlot,
+            feeling: emotionTypes,
+            outdoor: targetOutingFrequency)
+    }
+}

--- a/Projects/DataSource/Sources/DTO/RecommendedRoutineDTO.swift
+++ b/Projects/DataSource/Sources/DTO/RecommendedRoutineDTO.swift
@@ -12,7 +12,7 @@ struct RecommendedRoutineDTO: Decodable {
     let routineName: String
     let routineDescription: String
     let routineLevel: String?
-    let routineType: String
+    let routineType: String?
     let subRoutines: [RecommendedSubRoutineDTO]
 
     enum CodingKeys: String, CodingKey {
@@ -32,6 +32,11 @@ extension RecommendedRoutineDTO {
             routineCategory = RoutineCategoryType(rawValue: category)
         }
 
+        var type: RoutineCategoryType?
+        if let routineType {
+            type = RoutineCategoryType(rawValue: routineType)
+        }
+
         var level: RoutineLevelType?
         if let routineLevel {
             level = RoutineLevelType(rawValue: routineLevel)
@@ -41,7 +46,7 @@ extension RecommendedRoutineDTO {
             title: routineName,
             description: routineDescription,
             category: routineCategory,
-            type: RoutineCategoryType(rawValue: routineType) ?? .rest,
+            type: type,
             level: level,
             subRoutines: subRoutines.compactMap({ $0.toRecommendedSubRoutineEntity() }))
     }

--- a/Projects/DataSource/Sources/Endpoint/OnboardingEndpoint.swift
+++ b/Projects/DataSource/Sources/Endpoint/OnboardingEndpoint.swift
@@ -6,29 +6,32 @@
 //
 
 enum OnboardingEndpoint {
-    case registerOnboarding(choices: [String: String])
+    case loadOnboardingResult
+    case registerOnboarding(onboarding: OnboardingDTO)
     case registerRecommendedRoutine(selectedRoutines: [Int])
 }
 
 extension OnboardingEndpoint: Endpoint {
     var baseURL: String {
-        switch self {
-        case .registerOnboarding:
-            return AppProperties.baseURL + "/api/v1/onboardings"
-        case .registerRecommendedRoutine:
-            return AppProperties.baseURL + "/api/v2/onboardings"
-        }
+        return AppProperties.baseURL + "/api/v2/onboardings"
     }
 
     var path: String {
         switch self {
-        case .registerOnboarding: baseURL
-        case .registerRecommendedRoutine: baseURL + "/routines"
+        case .registerOnboarding, .loadOnboardingResult:
+            return baseURL
+        case .registerRecommendedRoutine: 
+            return baseURL + "/routines"
         }
     }
     
     var method: HTTPMethod {
-        return .post
+        switch self {
+        case .loadOnboardingResult:
+            return .get
+        case .registerOnboarding, .registerRecommendedRoutine:
+            return .post
+        }
     }
     
     var headers: [String : String] {
@@ -45,10 +48,12 @@ extension OnboardingEndpoint: Endpoint {
     
     var bodyParameters: [String : Any] {
         switch self {
-        case .registerOnboarding(let choices):
-            return choices
+        case .registerOnboarding(let onboarding):
+            return onboarding.dictionary
         case .registerRecommendedRoutine(let selectedRoutines):
             return ["recommendedRoutineIds": selectedRoutines]
+        default:
+            return [:]
         }
     }
 

--- a/Projects/DataSource/Sources/Repository/OnboardingRepository.swift
+++ b/Projects/DataSource/Sources/Repository/OnboardingRepository.swift
@@ -11,23 +11,27 @@ final class OnboardingRepository: OnboardingRepositoryProtocol {
     private let networkService = NetworkService.shared
     private let userDefaultsStorage = UserDefaultsStorage.shared
 
-    func registerOnboarding(onboardingChoices: [String : String]) async throws -> [RecommendedRoutineEntity] {
-        let endpoint = OnboardingEndpoint.registerOnboarding(choices: onboardingChoices)
-        guard let response = try await networkService.request(endpoint: endpoint, type: RecommendedRoutineListResponseDTO.self)
-        else { return [] }
+    func loadOnboardingResult() async throws -> OnboardingEntity {
+        let endpoint = OnboardingEndpoint.loadOnboardingResult
+        guard let response = try await networkService.request(endpoint: endpoint, type: OnboardingResponseDTO.self)
+        else { throw UserError.onboardingLoadFailed }
 
-        guard userDefaultsStorage.save(true, forKey: UserDefaultsKey.onboarding.rawValue)
-        else { throw UserError.onboardingSaveFailed }
-
-        let recommendedRoutineEntity = response.recommendedRoutines.compactMap({ $0.toRecommendedRoutineEntity() })
-        return recommendedRoutineEntity
+        let onboardingEntity = response.toOnboardingEntity()
+        return onboardingEntity
     }
 
-    func isOnboardingDone() -> Bool {
-        guard let isOnboardingDone: Bool = userDefaultsStorage.load(forKey: UserDefaultsKey.onboarding.rawValue)
-        else { return false }
-
-        return isOnboardingDone
+    func registerOnboarding(onboardingEntity: OnboardingEntity) async throws -> [RecommendedRoutineEntity] {
+        let onboardingDTO = OnboardingDTO(
+            timeSlot: onboardingEntity.time,
+            emotionType: onboardingEntity.feeling,
+            realOutingFrequency: onboardingEntity.frequency,
+            targetOutingFrequency: onboardingEntity.outdoor)
+        let endpoint = OnboardingEndpoint.registerOnboarding(onboarding: onboardingDTO)
+        guard let response = try await networkService.request(endpoint: endpoint, type: RecommendedRoutineListResponseDTO.self)
+        else { return [] }
+        
+        let recommendedRoutineEntity = response.recommendedRoutines.compactMap({ $0.toRecommendedRoutineEntity() })
+        return recommendedRoutineEntity
     }
 
     func registerRecommendedRoutines(selectedRoutines: [Int]) async throws {

--- a/Projects/Domain/Sources/Entity/Enum/OnboardingChoiceType.swift
+++ b/Projects/Domain/Sources/Entity/Enum/OnboardingChoiceType.swift
@@ -5,25 +5,25 @@
 //  Created by 최정인 on 7/15/25.
 //
 
-public enum OnboardingChoiceType: CaseIterable {
-    case morningTime
-    case eveningTime
-    case allTime
+public enum OnboardingChoiceType: String, CaseIterable {
+    case morningTime = "08:00:00"
+    case eveningTime = "20:00:00"
+    case allTime = "00:00:00"
 
-    case never
-    case rarely
-    case sometimes
-    case often
+    case never = "NEVER"
+    case rarely = "SHORT"
+    case sometimes = "SOMETIMES"
+    case often = "OFTEN"
 
-    case stability
-    case connection
-    case growth
-    case vitality
+    case stability = "STABILITY"
+    case connection = "CONNECTEDNESS"
+    case growth = "GROWTH"
+    case vitality = "VITALITY"
 
-    case once
-    case twoToThree
-    case fourOrMore
-    case notSure
+    case once = "ONE_PER_WEEK"
+    case twoToThree = "TWO_TO_THREE_PER_WEEK"
+    case fourOrMore = "MORE_THAN_FOUR_PER_WEEK"
+    case notSure = "UNKNOWN"
 
     public var onboardingType: OnboardingType {
         switch self {
@@ -45,29 +45,6 @@ public enum OnboardingChoiceType: CaseIterable {
         case .twoToThree: .outdoor
         case .fourOrMore: .outdoor
         case .notSure: .outdoor
-        }
-    }
-
-    var value: String {
-        switch self {
-        case .morningTime: "08:00:00"
-        case .eveningTime: "20:00:00"
-        case .allTime: "00:00:00"
-
-        case .never: "NEVER"
-        case .rarely: "SHORT"
-        case .sometimes: "SOMETIMES"
-        case .often: "OFTEN"
-
-        case .stability: "STABILITY"
-        case .connection: "CONNECTEDNESS"
-        case .growth: "GROWTH"
-        case .vitality: "VITALITY"
-
-        case .once: "ONE_PER_WEEK"
-        case .twoToThree: "TWO_TO_THREE_PER_WEEK"
-        case .fourOrMore: "MORE_THAN_FOUR_PER_WEEK"
-        case .notSure: "UNKNOWN"
         }
     }
 }

--- a/Projects/Domain/Sources/Entity/OnboardingEntity.swift
+++ b/Projects/Domain/Sources/Entity/OnboardingEntity.swift
@@ -1,0 +1,25 @@
+//
+//  OnboardingEntity.swift
+//  Domain
+//
+//  Created by 최정인 on 8/27/25.
+//
+
+public struct OnboardingEntity {
+    public let time: String
+    public let feeling: [String]
+    public let frequency: String?
+    public let outdoor: String
+
+    public init(
+        time: String,
+        feeling: [String],
+        frequency: String? = nil,
+        outdoor: String
+    ) {
+        self.time = time
+        self.feeling = feeling
+        self.frequency = frequency
+        self.outdoor = outdoor
+    }
+}

--- a/Projects/Domain/Sources/Entity/RecommendedRoutineEntity.swift
+++ b/Projects/Domain/Sources/Entity/RecommendedRoutineEntity.swift
@@ -10,7 +10,7 @@ public struct RecommendedRoutineEntity {
     public let title: String
     public let description: String
     public let category: RoutineCategoryType?
-    public let type: RoutineCategoryType
+    public let type: RoutineCategoryType?
     public let level: RoutineLevelType?
     public let subRoutines: [RecommendedSubRoutineEntity]
 
@@ -19,7 +19,7 @@ public struct RecommendedRoutineEntity {
         title: String,
         description: String,
         category: RoutineCategoryType?,
-        type: RoutineCategoryType,
+        type: RoutineCategoryType?,
         level: RoutineLevelType?,
         subRoutines: [RecommendedSubRoutineEntity]
     ) {

--- a/Projects/Domain/Sources/Protocol/Repository/OnboardingRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/Repository/OnboardingRepositoryProtocol.swift
@@ -6,16 +6,17 @@
 //
 
 public protocol OnboardingRepositoryProtocol {
+    /// 이전에 선택했던 온보딩 결과를 불러옵니다.
+    /// - Returns: 온보딩 선택 결과
+    func loadOnboardingResult() async throws -> OnboardingEntity
+
     /// 선택한 온보딩 결과를 저장하고, 추천 루틴을 받습니다.
-    /// - Parameter onboardingChoices: 선택한 온보딩 항목 Dictionary
+    /// - Parameter onboardingEntity: 선택한 온보딩 항목
     /// - Returns: 온보딩 결과를 바탕으로 받은 추천루틴 목록
-    func registerOnboarding(onboardingChoices: [String: String]) async throws -> [RecommendedRoutineEntity]
+    func registerOnboarding(onboardingEntity: OnboardingEntity) async throws -> [RecommendedRoutineEntity]
 
     /// 선택한 추천 루틴을 등록합니다.
     /// - Parameter selectedRoutines: 선택한 추천 루틴 ID 목록
     func registerRecommendedRoutines(selectedRoutines: [Int]) async throws
 
-    /// 온보딩 여부를 반환합니다.
-    /// - Returns: 온보딩 여부
-    func isOnboardingDone() -> Bool
 }

--- a/Projects/Domain/Sources/Protocol/UseCase/ResultRecommendedRoutineUseCaseProtocol.swift
+++ b/Projects/Domain/Sources/Protocol/UseCase/ResultRecommendedRoutineUseCaseProtocol.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public protocol ResultRecommendedRoutineUseCaseProtocol {
     /// 선택한 온보딩 결과를 저장하고, 추천 루틴을 받습니다.
-    /// - Parameter onboardingChoices: 선택한 온보딩 항목 list
+    /// - Parameter onboardingEntity: 선택한 온보딩 항목
     /// - Returns: 온보딩 결과를 바탕으로 받은 추천루틴 목록
-    func fetchResultRecommendedRoutines(onboardingChoices: [OnboardingChoiceType]) async throws -> [RecommendedRoutineEntity]
+    func fetchResultRecommendedRoutines(onboardingEntity: OnboardingEntity) async throws -> [RecommendedRoutineEntity]
 
     /// 감정 구슬을 등록하고 그에 따른 추천 루틴 리스트를 받습니다.
     /// - Parameter emotion: 감정 구슬 타입 String

--- a/Projects/Domain/Sources/UseCase/ResultRecommendedRoutine/ResultRecommendedRoutineUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/ResultRecommendedRoutine/ResultRecommendedRoutineUseCase.swift
@@ -15,9 +15,8 @@ public final class ResultRecommendedRoutineUseCase: ResultRecommendedRoutineUseC
         self.emotionRepository = emotionRepository
     }
 
-    public func fetchResultRecommendedRoutines(onboardingChoices: [OnboardingChoiceType]) async throws -> [RecommendedRoutineEntity] {
-        let choices = convertToDictionary(onboardingChoices: onboardingChoices)
-        let recommendedRoutines = try await onboardingRepository.registerOnboarding(onboardingChoices: choices)
+    public func fetchResultRecommendedRoutines(onboardingEntity: OnboardingEntity) async throws -> [RecommendedRoutineEntity] {
+        let recommendedRoutines = try await onboardingRepository.registerOnboarding(onboardingEntity: onboardingEntity)
         return recommendedRoutines
     }
 
@@ -28,16 +27,5 @@ public final class ResultRecommendedRoutineUseCase: ResultRecommendedRoutineUseC
 
     public func registerRecommendedRoutines(selectedRoutines: [Int]) async throws {
         try await onboardingRepository.registerRecommendedRoutines(selectedRoutines: selectedRoutines)
-    }
-
-    private func convertToDictionary(onboardingChoices: [OnboardingChoiceType]) -> [String: String] {
-        var result: [String: String] = [:]
-        let onboardingTypes: [OnboardingType] = [.time, .frequency, .feeling, .outdoor]
-        for type in onboardingTypes {
-            guard let choice = onboardingChoices.first(where: { $0.onboardingType == type })
-            else { break }
-            result[choice.onboardingType.key] = choice.value
-        }
-        return result
     }
 }

--- a/Projects/Presentation/Sources/Common/Component/ToastMessageView.swift
+++ b/Projects/Presentation/Sources/Common/Component/ToastMessageView.swift
@@ -39,7 +39,7 @@ public final class ToastMessageView: UIView {
         self.alpha = 0
         self.isHidden = true
 
-        backgroundColor = BitnagilColor.navy400
+        backgroundColor = BitnagilColor.gray30
         layer.cornerRadius = 8
         layer.masksToBounds = true
 

--- a/Projects/Presentation/Sources/Common/Component/ToastView.swift
+++ b/Projects/Presentation/Sources/Common/Component/ToastView.swift
@@ -1,0 +1,83 @@
+//
+//  ToastView.swift
+//  Presentation
+//
+//  Created by 최정인 on 9/2/25.
+//
+
+import SnapKit
+import UIKit
+
+final class ToastView: UIView {
+    private enum Layout {
+        static let horizontalMargin: CGFloat = 16
+        static let checkIconSize: CGFloat = 24
+        static let messageLabelLeadingSpacing: CGFloat = 8
+    }
+
+    private let checkIcon = UIImageView()
+    private let messageLabel = UILabel()
+    private let message: String
+
+    init(message: String) {
+        self.message = message
+        super.init(frame: .zero)
+        configureAttribute()
+        configureLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureAttribute() {
+        alpha = 0
+        isHidden = true
+
+        layer.masksToBounds = true
+        layer.cornerRadius = 12
+        backgroundColor = BitnagilColor.gray30
+
+        checkIcon.image = BitnagilIcon.orangeCheckedCircleIcon
+
+        messageLabel.text = message
+        messageLabel.font = BitnagilFont(style: .body2, weight: .medium).font
+        messageLabel.textColor = .white
+    }
+
+    private func configureLayout() {
+        addSubview(checkIcon)
+        addSubview(messageLabel)
+
+        checkIcon.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().offset(Layout.horizontalMargin)
+            make.size.equalTo(Layout.checkIconSize)
+        }
+
+        messageLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(checkIcon.snp.trailing).offset(Layout.messageLabelLeadingSpacing)
+            make.trailing.equalToSuperview().offset(-Layout.horizontalMargin)
+        }
+    }
+
+    func showToastMessageView() {
+        alpha = 0
+        isHidden = false
+
+        UIView.animate(withDuration: 0.35, delay: 0.01) {
+            self.alpha = 1
+        } completion: { [weak self] _ in
+            self?.hideToastMessageView()
+        }
+    }
+
+    private func hideToastMessageView() {
+        UIView.animate(withDuration: 0.35, delay: 2.0) {
+            self.alpha = 0
+        } completion: { _ in
+            self.isHidden = true
+        }
+    }
+}

--- a/Projects/Presentation/Sources/Common/Extension/Notification+.swift
+++ b/Projects/Presentation/Sources/Common/Extension/Notification+.swift
@@ -1,0 +1,12 @@
+//
+//  Notification+.swift
+//  Presentation
+//
+//  Created by 최정인 on 9/3/25.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let showRecommendedRoutineToast = Notification.Name("showRecommendedRoutineToast")
+}

--- a/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
+++ b/Projects/Presentation/Sources/Common/PresentationDependencyAssembler.swift
@@ -50,7 +50,10 @@ public struct PresentationDependencyAssembler: DependencyAssemblerProtocol {
             guard let userDataRepository = container.resolve(type: UserDataRepositoryProtocol.self)
             else { fatalError("userDataRepository 의존성이 등록되지 않았습니다.") }
 
-            return OnboardingViewModel(userDataRepository: userDataRepository)
+            guard let onboardingRepository = container.resolve(type: OnboardingRepositoryProtocol.self)
+            else { fatalError("userDataRepository 의존성이 등록되지 않았습니다.") }
+
+            return OnboardingViewModel(userDataRepository: userDataRepository, onboardingRepository: onboardingRepository)
         }
 
         DIContainer.shared.register(type: RecommendedRoutineViewModel.self) { container in

--- a/Projects/Presentation/Sources/EmotionRegister/View/EmotionRegisterView.swift
+++ b/Projects/Presentation/Sources/EmotionRegister/View/EmotionRegisterView.swift
@@ -127,7 +127,7 @@ extension EmotionRegisterView: UICollectionViewDelegate {
         else { fatalError("resultRecommendedRoutineViewModel 의존성이 등록되지 않았습니다.") }
         resultRecommendedRoutineViewModel.configure(viewModelType: .emotion(emotion: selectedEmotion))
 
-        let resultRecommendedRoutineView = ResultRecommendedRoutineView(entryPoint: .emotion, viewModel: resultRecommendedRoutineViewModel)
+        let resultRecommendedRoutineView = ResultRecommendedRoutineViewController(entryPoint: .emotion, viewModel: resultRecommendedRoutineViewModel)
         self.navigationController?.pushViewController(resultRecommendedRoutineView, animated: true)
     }
 }

--- a/Projects/Presentation/Sources/Login/View/Component/TotalAgreementButton.swift
+++ b/Projects/Presentation/Sources/Login/View/Component/TotalAgreementButton.swift
@@ -46,7 +46,7 @@ final class TotalAgreementButton: UIButton {
         stackView.isUserInteractionEnabled = false
 
         checkButton.image = BitnagilIcon.checkIcon
-        checkButton.tintColor = BitnagilColor.navy100
+        checkButton.tintColor = BitnagilColor.gray90
         checkButton.contentMode = .scaleAspectFit
 
         buttonLabel.text = "전체동의"

--- a/Projects/Presentation/Sources/Login/View/TermsAgreementViewController.swift
+++ b/Projects/Presentation/Sources/Login/View/TermsAgreementViewController.swift
@@ -120,11 +120,12 @@ final class TermsAgreementViewController: BaseViewController<LoginViewModel> {
                 guard let self else { return }
                 if agreementResult {
                     BitnagilLogger.log(logType: .debug, message: "약관 동의 성공")
-                    guard let onboardingViewModel = DIContainer.shared.resolve(type: OnboardingViewModel.self) else {
-                        fatalError("onboardingViewModel 의존성이 등록되지 않았습니다.")
-                    }
-                    let onboardingView = OnboardingViewController(viewModel: onboardingViewModel, onboarding: .time)
-                    self.navigationController?.pushViewController(onboardingView, animated: true)
+
+                    guard let introViewModel = DIContainer.shared.resolve(type: IntroViewModel.self)
+                    else { fatalError("introViewModel 의존성이 등록되지 않았습니다.") }
+
+                    let introView = IntroViewController(viewModel: introViewModel)
+                    self.navigationController?.pushViewController(introView, animated: true)
                 } else {
                     // TODO: 약관 동의 실패 시, 에러 처리를 해야 합니다.
                     BitnagilLogger.log(logType: .error, message: "약관 동의 실패")

--- a/Projects/Presentation/Sources/MyPage/View/MypageView.swift
+++ b/Projects/Presentation/Sources/MyPage/View/MypageView.swift
@@ -167,14 +167,10 @@ extension MypageView: UITableViewDataSource {
             return
         }
 
-        guard let onboardingViewModel = DIContainer.shared.resolve(type: OnboardingViewModel.self) else {
-            fatalError("onboardingViewModel 의존성이 등록되지 않았습니다.")
-        }
+        guard let onboardingViewModel = DIContainer.shared.resolve(type: OnboardingViewModel.self)
+        else { fatalError("onboardingViewModel 의존성이 등록되지 않았습니다.") }
 
-        let onboardingView = OnboardingViewController(
-            viewModel: onboardingViewModel,
-            onboarding: .time,
-            isFromMypage: true)
+        let onboardingView = OnboardingResultViewController(viewModel: onboardingViewModel, entryPoint: .myPagePrevious)
         onboardingView.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(onboardingView, animated: true)
     }

--- a/Projects/Presentation/Sources/Onboarding/Model/RecommendedRoutine.swift
+++ b/Projects/Presentation/Sources/Onboarding/Model/RecommendedRoutine.swift
@@ -43,7 +43,7 @@ extension RecommendedRoutineEntity {
             subTitle: description,
             subRoutines: subRoutines.map({ $0.title }),
             routineCategory: category ?? .recommendation,
-            routineType: type,
+            routineType: type ?? .recommendation,
             routineLevel: level ?? .easy
         )
     }

--- a/Projects/Presentation/Sources/Onboarding/View/OnboardingResultViewController.swift
+++ b/Projects/Presentation/Sources/Onboarding/View/OnboardingResultViewController.swift
@@ -12,6 +12,12 @@ import SnapKit
 import UIKit
 
 final class OnboardingResultViewController: BaseViewController<OnboardingViewModel> {
+    enum EntryPoint {
+        case onboarding
+        case myPagePrevious
+        case myPageResult
+    }
+
     private enum Layout {
         static let horizontalMargin: CGFloat = 20
         static let mainLabelMinTopSpacing: CGFloat = 60
@@ -42,17 +48,17 @@ final class OnboardingResultViewController: BaseViewController<OnboardingViewMod
     private let rectangleImageView = UIImageView()
     private let nameLabel = UILabel()
     private let resultStackView = UIStackView()
-    private let nextButton = PrimaryButton(buttonState: .default, buttonTitle: "다음")
+    private var nextButton = PrimaryButton(buttonState: .default, buttonTitle: "다음")
 
     private var isLayoutConfigured: Bool = false
     private var mainLabelTopConstraint: Constraint?
     private var resultGraphicViewTopConstraint: Constraint?
     private var rectangleHeightConstraint: Constraint?
 
-    private let isFromMypage: Bool
+    private let entryPoint: EntryPoint
     private var cancellables: Set<AnyCancellable>
-    init(viewModel: OnboardingViewModel, isFromMypage: Bool = false) {
-        self.isFromMypage = isFromMypage
+    init(viewModel: OnboardingViewModel, entryPoint: EntryPoint = .onboarding) {
+        self.entryPoint = entryPoint
         cancellables = []
         super.init(viewModel: viewModel)
     }
@@ -64,7 +70,14 @@ final class OnboardingResultViewController: BaseViewController<OnboardingViewMod
     override func viewDidLoad() {
         super.viewDidLoad()
         viewModel.action(input: .loadNickname)
-        viewModel.action(input: .makeOnboardingResult)
+
+        switch entryPoint {
+        case .onboarding, .myPageResult:
+            viewModel.action(input: .makeOnboardingResult)
+
+        case .myPagePrevious:
+            viewModel.action(input: .loadOnboardingResult)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -88,7 +101,10 @@ final class OnboardingResultViewController: BaseViewController<OnboardingViewMod
     }
 
     override func configureAttribute() {
-        let text = "이제 포모가 당신에게\n꼭 맞는 루틴을 찾아줄거예요."
+        var text = "이제 포모가 당신에게\n꼭 맞는 루틴을 찾아줄거예요."
+        if entryPoint == .myPagePrevious {
+            text = "이전에 설정한 목표에요!\n변경하시겠어요?"
+        }
         mainLabel.attributedText = BitnagilFont(style: .title2, weight: .bold).attributedString(text: text)
         mainLabel.textColor = BitnagilColor.gray10
         mainLabel.numberOfLines = 2
@@ -104,9 +120,24 @@ final class OnboardingResultViewController: BaseViewController<OnboardingViewMod
         resultStackView.axis = .vertical
         resultStackView.spacing = Layout.resultStackViewSpacing
 
+        if entryPoint == .myPagePrevious {
+            nextButton = PrimaryButton(buttonState: .default, buttonTitle: "변경하기")
+        }
+
         nextButton.addAction(
             UIAction { [weak self] _ in
-                self?.viewModel.action(input: .fetchOnboardingChoices)
+                guard let self else { return }
+                switch self.entryPoint {
+                case .onboarding, .myPageResult:
+                    self.viewModel.action(input: .fetchOnboardingChoices)
+
+                case .myPagePrevious:
+                    let onboardingView = OnboardingViewController(
+                        viewModel: self.viewModel,
+                        onboarding: .time,
+                        isFromMypage: true)
+                    self.navigationController?.pushViewController(onboardingView, animated: true)
+                }
             }, for: .touchUpInside)
     }
 
@@ -114,7 +145,13 @@ final class OnboardingResultViewController: BaseViewController<OnboardingViewMod
         let safeArea = view.safeAreaLayoutGuide
         view.backgroundColor = .systemBackground
         navigationController?.setNavigationBarHidden(true, animated: false)
-        configureCustomNavigationBar(navigationBarStyle: .withProgressBar(step: OnboardingType.allCases.count + 1))
+
+        switch entryPoint {
+        case .onboarding, .myPageResult:
+            configureCustomNavigationBar(navigationBarStyle: .withProgressBar(step: OnboardingType.allCases.count + 1))
+        case .myPagePrevious:
+            configureCustomNavigationBar(navigationBarStyle: .withBackButton(title: ""))
+        }
 
         view.addSubview(mainLabel)
         view.addSubview(resultGraphicView)
@@ -180,8 +217,8 @@ final class OnboardingResultViewController: BaseViewController<OnboardingViewMod
 
         viewModel.output.onboardingChoicesPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] onboardingChoices in
-                self?.goToResultRecommendedRoutineView(onboardingChoices: onboardingChoices)
+            .sink { [weak self] onboardingEntity in
+                self?.goToResultRecommendedRoutineView(onboardingEntity: onboardingEntity)
             }
             .store(in: &cancellables)
     }
@@ -217,6 +254,7 @@ final class OnboardingResultViewController: BaseViewController<OnboardingViewMod
             rectangleHeightConstraint?.update(offset: Layout.rectangleImageViewMaxHeight)
             resultGraphicViewTopConstraint?.update(offset: Layout.resultGraphicViewTopMinSpacing)
         }
+
         feelingResultStackView.snp.makeConstraints { make in
             make.height.equalTo(ifNeedExpandFeelingResult ? Layout.resultLabelMaxHeight : Layout.resultLabelHeight)
         }
@@ -232,18 +270,28 @@ final class OnboardingResultViewController: BaseViewController<OnboardingViewMod
         }
     }
 
-    private func goToResultRecommendedRoutineView(onboardingChoices: [OnboardingChoiceType]) {
-        guard let resultRecommendedRoutineViewModel = DIContainer.shared.resolve(type: ResultRecommendedRoutineViewModel.self)
-        else{ fatalError("resultRecommendedRoutineViewModel 의존성이 등록되지 않았습니다.") }
+    private func goToResultRecommendedRoutineView(onboardingEntity: OnboardingEntity) {
+        var nextView: UIViewController?
+        switch entryPoint {
+        case .onboarding:
+            guard let resultRecommendedRoutineViewModel = DIContainer.shared.resolve(type: ResultRecommendedRoutineViewModel.self)
+            else { fatalError("resultRecommendedRoutineViewModel 의존성이 등록되지 않았습니다.") }
 
-        var resultRecommendedView: ResultRecommendedRoutineView
-        if isFromMypage {
-            resultRecommendedRoutineViewModel.configure(viewModelType: .mypage(onboardingChoices: onboardingChoices))
-            resultRecommendedView = ResultRecommendedRoutineView(entryPoint: .mypage, viewModel: resultRecommendedRoutineViewModel)
-        } else {
-            resultRecommendedRoutineViewModel.configure(viewModelType: .onboarding(onboardingChoices: onboardingChoices))
-            resultRecommendedView = ResultRecommendedRoutineView(entryPoint: .onboarding, viewModel: resultRecommendedRoutineViewModel)
+            resultRecommendedRoutineViewModel.configure(viewModelType: .onboarding(onboardingEntity: onboardingEntity))
+            nextView = ResultRecommendedRoutineViewController(entryPoint: .onboarding, viewModel: resultRecommendedRoutineViewModel)
+
+        case .myPagePrevious:
+            break
+
+        case .myPageResult:
+            guard let resultRecommendedRoutineViewModel = DIContainer.shared.resolve(type: ResultRecommendedRoutineViewModel.self)
+            else{ fatalError("resultRecommendedRoutineViewModel 의존성이 등록되지 않았습니다.") }
+
+            resultRecommendedRoutineViewModel.configure(viewModelType: .mypage(onboardingEntity: onboardingEntity))
+            nextView = ResultRecommendedRoutineViewController(entryPoint: .mypage, viewModel: resultRecommendedRoutineViewModel)
         }
-        self.navigationController?.pushViewController(resultRecommendedView, animated: true)
+
+        guard let nextView else { return }
+        self.navigationController?.pushViewController(nextView, animated: true)
     }
 }

--- a/Projects/Presentation/Sources/Onboarding/View/OnboardingViewController.swift
+++ b/Projects/Presentation/Sources/Onboarding/View/OnboardingViewController.swift
@@ -239,7 +239,11 @@ final class OnboardingViewController: BaseViewController<OnboardingViewModel> {
                 onboarding: nextStep,
                 isFromMypage: isFromMypage)
         } else {
-            nextView = OnboardingResultViewController(viewModel: viewModel, isFromMypage: isFromMypage)
+            if isFromMypage {
+                nextView = OnboardingResultViewController(viewModel: viewModel, entryPoint: .myPageResult)
+            } else {
+                nextView = OnboardingResultViewController(viewModel: viewModel, entryPoint: .onboarding)
+            }
         }
         guard let nextView else { return }
         self.navigationController?.pushViewController(nextView, animated: true)

--- a/Projects/Presentation/Sources/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Projects/Presentation/Sources/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -15,6 +15,7 @@ final class OnboardingViewModel: ViewModel {
         case selectOnboardingChoice(selectedChoice: OnboardingChoiceType)
         case fetchOnboardingChoice(onboarding: OnboardingType)
         case fetchOnboardingChoices
+        case loadOnboardingResult
         case makeOnboardingResult
     }
 
@@ -25,7 +26,7 @@ final class OnboardingViewModel: ViewModel {
         let feelingOnboardingChoicePublisher: AnyPublisher<Set<OnboardingChoiceType>, Never>
         let outdoorOnboardingChoicePublisher: AnyPublisher<OnboardingChoiceType?, Never>
         let onboardingResultPublisher: AnyPublisher<[String], Never>
-        let onboardingChoicesPublisher: AnyPublisher<[OnboardingChoiceType], Never>
+        let onboardingChoicesPublisher: AnyPublisher<OnboardingEntity, Never>
         let nextButtonPublisher: AnyPublisher<Bool, Never>
     }
 
@@ -36,12 +37,14 @@ final class OnboardingViewModel: ViewModel {
     private let feelingOnboardingChoiceSubject = CurrentValueSubject<Set<OnboardingChoiceType>, Never>([])
     private let outdoorOnboardingChoiceSubject = CurrentValueSubject<OnboardingChoiceType?, Never>(nil)
     private let onboardingResultSubject = CurrentValueSubject<[String], Never>([])
-    private let onboardingChoicesSubject = PassthroughSubject<[OnboardingChoiceType], Never>()
+    private let onboardingChoicesSubject = PassthroughSubject<OnboardingEntity, Never>()
     private let nextButtonSubject = PassthroughSubject<Bool, Never>()
 
     private let userDataRepository: UserDataRepositoryProtocol
-    init(userDataRepository: UserDataRepositoryProtocol) {
+    private let onboardingRepository: OnboardingRepositoryProtocol
+    init(userDataRepository: UserDataRepositoryProtocol, onboardingRepository: OnboardingRepositoryProtocol) {
         self.userDataRepository = userDataRepository
+        self.onboardingRepository = onboardingRepository
         self.output = Output(
             nicknamePublisher: nicknameSubject.eraseToAnyPublisher(),
             timeOnboardingChoicePublisher: timeOnboardingChoiceSubject.eraseToAnyPublisher(),
@@ -67,6 +70,9 @@ final class OnboardingViewModel: ViewModel {
 
         case .fetchOnboardingChoices:
             makeOnboardingChoices()
+
+        case .loadOnboardingResult:
+            loadOnboardingResult()
 
         case .makeOnboardingResult:
             makeOnboardingResult()
@@ -166,6 +172,30 @@ final class OnboardingViewModel: ViewModel {
         nextButtonSubject.send(result)
     }
 
+    // 이전 온보딩 선택 결과를 불러옵니다.
+    private func loadOnboardingResult() {
+        Task {
+            do {
+                let onboardingEntity = try await onboardingRepository.loadOnboardingResult()
+
+                let feelingOnboardingChoices = onboardingEntity.feeling.compactMap({ OnboardingChoiceType(rawValue: $0 )})
+                let feelingResult = feelingOnboardingChoices.compactMap({ $0.resultTitle }).joined(separator: ", ")
+
+                guard
+                    let timeOnboardingChoice = OnboardingChoiceType(rawValue: onboardingEntity.time),
+                    let outdoorOnboardingChoice = OnboardingChoiceType(rawValue: onboardingEntity.outdoor),
+                    let timeResult = timeOnboardingChoice.resultTitle,
+                    let outdoorResult = outdoorOnboardingChoice.resultTitle
+                else { return }
+
+                let result = [timeResult, feelingResult, outdoorResult]
+                onboardingResultSubject.send(result)
+            } catch {
+                // TODO: 에러 처리
+            }
+        }
+    }
+
     // 온보딩 결과 텍스트를 만듭니다.
     private func makeOnboardingResult() {
         let feelingOnboardingChoice = feelingOnboardingChoiceSubject.value
@@ -186,8 +216,6 @@ final class OnboardingViewModel: ViewModel {
 
     // 온보딩 선택지를 통합합니다.
     private func makeOnboardingChoices() {
-        var onboardingChoices: [OnboardingChoiceType] = []
-
         let feelingOnboarding = Array(feelingOnboardingChoiceSubject.value)
         guard
             let timeOnboarding = timeOnboardingChoiceSubject.value,
@@ -196,11 +224,12 @@ final class OnboardingViewModel: ViewModel {
             let outdoorOnboarding = outdoorOnboardingChoiceSubject.value
         else { return }
 
-        onboardingChoices.append(timeOnboarding)
-        onboardingChoices += feelingOnboarding
-        onboardingChoices.append(frequencyOnboarding)
-        onboardingChoices.append(outdoorOnboarding)
+        let onboardingEntity = OnboardingEntity(
+            time: timeOnboarding.rawValue,
+            feeling: feelingOnboarding.map({ $0.rawValue }),
+            frequency: frequencyOnboarding.rawValue,
+            outdoor: outdoorOnboarding.rawValue)
 
-        onboardingChoicesSubject.send(onboardingChoices)
+        onboardingChoicesSubject.send(onboardingEntity)
     }
 }

--- a/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineViewController.swift
+++ b/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineViewController.swift
@@ -32,7 +32,8 @@ final class RecommendedRoutineViewController: BaseViewController<RecommendedRout
         static let floatingMenuBottomSpacing: CGFloat = 15
         static let floatingMenuHeight: CGFloat = 64
         static let floatingMenuWidth: CGFloat = 144
-        static let toastMessageBottomSpacing: CGFloat = 19
+        static let toastMessageViewHeight: CGFloat = 52
+        static let toastMessageViewBottomSpacing: CGFloat = 38
     }
 
     private let categoryView = RoutineCategoryView()
@@ -52,6 +53,7 @@ final class RecommendedRoutineViewController: BaseViewController<RecommendedRout
     private let dimmedView = UIView()
     private let floatingButton = FloatingButton()
     private let floatingMenu = FloatingMenuView()
+    private let toastMessageView = ToastView(message: "맞춤 추천 루틴이 변경되었습니다.")
     private var cancellables: Set<AnyCancellable>
 
     public override init(viewModel: RecommendedRoutineViewModel) {
@@ -128,6 +130,8 @@ final class RecommendedRoutineViewController: BaseViewController<RecommendedRout
         view.addSubview(floatingMenu)
         view.addSubview(floatingButton)
 
+        view.addSubview(toastMessageView)
+
         categoryView.snp.makeConstraints { make in
             make.leading.equalTo(safeArea)
             make.trailing.equalTo(safeArea)
@@ -191,6 +195,13 @@ final class RecommendedRoutineViewController: BaseViewController<RecommendedRout
         dimmedView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+
+        toastMessageView.snp.makeConstraints { make in
+            make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
+            make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
+            make.height.equalTo(Layout.toastMessageViewHeight)
+            make.bottom.equalTo(safeArea).inset(Layout.toastMessageViewBottomSpacing)
+        }
     }
 
     override func bind() {
@@ -217,6 +228,13 @@ final class RecommendedRoutineViewController: BaseViewController<RecommendedRout
                     self?.isExistEmotion = isExistEmotion
                     self?.showEmotionButton(isShowEmotionButton: false)
                 }
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .showRecommendedRoutineToast)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.toastMessageView.showToastMessageView()
             }
             .store(in: &cancellables)
     }

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
@@ -343,6 +343,7 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
                 self.navigationController?.popToRootViewController(animated: false)
                 tabBarView.selectedIndex = 1
             }
+            viewModel.action(input: .showRecommendedRoutineToastMessageView)
 
         case .emotion:
             viewModel.action(input: .fetchSelectedRoutineId)

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
@@ -11,8 +11,7 @@ import Shared
 import SnapKit
 import UIKit
 
-final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRoutineViewModel> {
-
+final class ResultRecommendedRoutineViewController: BaseViewController<ResultRecommendedRoutineViewModel> {
     enum EntryPoint {
         case onboarding
         case mypage
@@ -23,18 +22,16 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
             case .onboarding, .mypage:
                 "당신만의 추천 루틴이 생성되었어요!"
             case .emotion:
-                "오늘 감정에 따른\n루틴을 추천드릴게요!"
+                "오늘의 감정에 맞는 루틴을 준비했어요!"
             }
         }
 
         var subLabelText: String {
             switch self {
-            case .onboarding:
+            case .onboarding, .mypage:
                 "선택한 루틴은 홈에서 자유롭게 수정할 수 있어요."
-            case .mypage:
-                "생활 패턴과 목표에 맞춰 다시 구성된 맞춤 루틴이에요.\n원하는 루틴을 선택해서 가볍게 시작해보세요."
             case .emotion:
-                "오늘 당신의 감정 상태에 맞춰 구성된 맞춤 루틴이에요.\n원하는 루틴을 선택해서 가볍게 시작해보세요."
+                "원하는 루틴을 골라 가볍게 시작해 보세요."
             }
         }
 
@@ -42,7 +39,7 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
             switch self {
             case .onboarding: "등록하기"
             case .mypage: "확인"
-            case .emotion: "루틴 등록하기"
+            case .emotion: "맞춤 추천 루틴보러 가기"
             }
         }
 
@@ -68,17 +65,16 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
     private enum Layout {
         static let horizontalMargin: CGFloat = 20
         static let mainLabelMinTopSpacing: CGFloat = 60
-        static let mainLabelMaxTopSpacing: CGFloat = 83
-        static let mainLabelMinHeight: CGFloat = 30
-        static let mainLabelHeight: CGFloat = 60
-        static let subLabelTopSpacing: CGFloat = 10
-        static let subLabelMinHeight: CGFloat = 24
-        static let subLabelHeight: CGFloat = 40
+        static let mainLabelMaxTopSpacing: CGFloat = 86
+        static let mainLabelHeight: CGFloat = 30
+        static let subLabelTopSpacing: CGFloat = 5
+        static let subLabelHeight: CGFloat = 24
         static let routineStackViewSpacing: CGFloat = 12
         static let routineStackViewTopSpacing: CGFloat = 28
         static let routineButtonHeight: CGFloat = 74
         static let confirmButtonHeight: CGFloat = 54
         static let confirmButtonBottomSpacing: CGFloat = 10
+        static let confirmButtonBottomMaxSpacing: CGFloat = 20
         static let skipButtonLabelFontSize: CGFloat = 14
         static let skipButtonLabelLineHeight: CGFloat = 20
         static let skipButtonHeight: CGFloat = 54
@@ -133,23 +129,11 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
         let mainLabelText = entryPoint.mainLabelText
         mainLabel.attributedText = BitnagilFont(style: .title2, weight: .bold).attributedString(text: mainLabelText)
         mainLabel.textColor = BitnagilColor.gray10
-        switch entryPoint {
-        case .onboarding:
-            mainLabel.numberOfLines = 1
-        case .mypage, .emotion:
-            mainLabel.numberOfLines = 2
-        }
         mainLabel.textAlignment = .left
 
         let subLabelText = entryPoint.subLabelText
         subLabel.attributedText = BitnagilFont(style: .body1, weight: .medium).attributedString(text: subLabelText)
         subLabel.textColor = BitnagilColor.gray50
-        switch entryPoint {
-        case .onboarding:
-            subLabel.numberOfLines = 1
-        case .mypage, .emotion:
-            subLabel.numberOfLines = 2
-        }
         subLabel.textAlignment = .left
 
         recommendedRoutineStackView.axis = .vertical
@@ -187,14 +171,14 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
             make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
             make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
             mainLabelTopConstraint = make.top.equalTo(safeArea).offset(Layout.mainLabelMinTopSpacing).constraint
-            make.height.equalTo(entryPoint == .onboarding ? Layout.mainLabelMinHeight : Layout.mainLabelHeight)
+            make.height.equalTo(Layout.mainLabelHeight)
         }
 
         subLabel.snp.makeConstraints { make in
             make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
             make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
-            make.top.equalTo(mainLabel.snp.bottom).offset(entryPoint == .onboarding ? 5 : Layout.subLabelTopSpacing)
-            make.height.equalTo(entryPoint == .onboarding ? Layout.subLabelMinHeight : Layout.subLabelHeight)
+            make.top.equalTo(mainLabel.snp.bottom).offset(Layout.subLabelTopSpacing)
+            make.height.equalTo(Layout.subLabelHeight)
         }
 
         recommendedRoutineStackView.snp.makeConstraints { make in
@@ -207,7 +191,7 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
             make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
             make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
             if entryPoint.isHiddenSkipButton {
-                make.bottom.equalTo(safeArea).inset(20)
+                make.bottom.equalTo(safeArea).inset(Layout.confirmButtonBottomMaxSpacing)
             } else {
                 make.bottom.equalTo(skipButton.snp.top).offset(-Layout.confirmButtonBottomSpacing)
             }
@@ -350,14 +334,16 @@ final class ResultRecommendedRoutineView: BaseViewController<ResultRecommendedRo
                let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
                 window.rootViewController = TabBarView()
             }
+
         case .mypage:
             if
                 let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                 let window = windowScene.windows.first(where: { $0.isKeyWindow }),
                 let tabBarView = window.rootViewController as? TabBarView {
                 self.navigationController?.popToRootViewController(animated: false)
-                tabBarView.selectedIndex = 2
+                tabBarView.selectedIndex = 1
             }
+
         case .emotion:
             viewModel.action(input: .fetchSelectedRoutineId)
         }

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
@@ -39,7 +39,7 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
             switch self {
             case .onboarding: "등록하기"
             case .mypage: "확인"
-            case .emotion: "맞춤 추천 루틴보러 가기"
+            case .emotion: "맞춤 추천 루틴 보러 가기"
             }
         }
 
@@ -126,6 +126,15 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
     }
 
     override func configureAttribute() {
+        view.backgroundColor = .systemBackground
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        switch entryPoint {
+        case .onboarding, .mypage:
+            configureCustomNavigationBar(navigationBarStyle: .withProgressBar(step: OnboardingType.allCases.count + 1))
+        case .emotion:
+            configureCustomNavigationBar(navigationBarStyle: .withBackButton(title: ""))
+        }
+
         let mainLabelText = entryPoint.mainLabelText
         mainLabel.attributedText = BitnagilFont(style: .title2, weight: .bold).attributedString(text: mainLabelText)
         mainLabel.textColor = BitnagilColor.gray10
@@ -156,9 +165,6 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
 
     override func configureLayout() {
         let safeArea = view.safeAreaLayoutGuide
-        view.backgroundColor = .systemBackground
-        navigationController?.setNavigationBarHidden(true, animated: false)
-        configureCustomNavigationBar(navigationBarStyle: .withProgressBar(step: OnboardingType.allCases.count + 1))
 
         view.addSubview(mainLabel)
         view.addSubview(subLabel)
@@ -168,28 +174,24 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
         view.addSubview(skipButton)
 
         mainLabel.snp.makeConstraints { make in
-            make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
-            make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
+            make.horizontalEdges.equalTo(safeArea).inset(Layout.horizontalMargin)
             mainLabelTopConstraint = make.top.equalTo(safeArea).offset(Layout.mainLabelMinTopSpacing).constraint
             make.height.equalTo(Layout.mainLabelHeight)
         }
 
         subLabel.snp.makeConstraints { make in
-            make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
-            make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
+            make.horizontalEdges.equalTo(safeArea).inset(Layout.horizontalMargin)
             make.top.equalTo(mainLabel.snp.bottom).offset(Layout.subLabelTopSpacing)
             make.height.equalTo(Layout.subLabelHeight)
         }
 
         recommendedRoutineStackView.snp.makeConstraints { make in
-            make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
-            make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
+            make.horizontalEdges.equalTo(safeArea).inset(Layout.horizontalMargin)
             make.top.equalTo(subLabel.snp.bottom).offset(Layout.routineStackViewTopSpacing)
         }
 
         confirmButton.snp.makeConstraints { make in
-            make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
-            make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
+            make.horizontalEdges.equalTo(safeArea).inset(Layout.horizontalMargin)
             if entryPoint.isHiddenSkipButton {
                 make.bottom.equalTo(safeArea).inset(Layout.confirmButtonBottomMaxSpacing)
             } else {
@@ -203,8 +205,7 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
         }
 
         skipButton.snp.makeConstraints { make in
-            make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
-            make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
+            make.horizontalEdges.equalTo(safeArea).inset(Layout.horizontalMargin)
             make.bottom.equalTo(safeArea).inset(Layout.skipButtonBottomSpacing)
             make.height.equalTo(Layout.skipButtonHeight)
         }

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Domain
+import Foundation
 import Shared
 
 final class ResultRecommendedRoutineViewModel: ViewModel {
@@ -21,6 +22,7 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
         case fetchSelectedRoutineId
         case selectRecommendedRoutine(routine: RecommendedRoutine)
         case registerRecommendedRoutine
+        case showRecommendedRoutineToastMessageView
     }
 
     struct Output {
@@ -65,6 +67,9 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
 
         case .registerRecommendedRoutine:
             registerRecommendedRoutine()
+
+        case .showRecommendedRoutineToastMessageView:
+            showRecommendedRoutineToastMessageView()
         }
     }
 
@@ -150,6 +155,15 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
                 BitnagilLogger.log(logType: .error, message: "\(error.localizedDescription)")
                 registerRoutineResultSubject.send(false)
             }
+        }
+    }
+
+    private func showRecommendedRoutineToastMessageView() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            NotificationCenter.default.post(
+                name: .showRecommendedRoutineToast,
+                object: nil,
+                userInfo: nil)
         }
     }
 }

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
@@ -10,10 +10,9 @@ import Domain
 import Shared
 
 final class ResultRecommendedRoutineViewModel: ViewModel {
-
     enum ResultRecommendedRoutineViewModelType {
-        case onboarding(onboardingChoices: [OnboardingChoiceType])
-        case mypage(onboardingChoices: [OnboardingChoiceType])
+        case onboarding(onboardingEntity: OnboardingEntity)
+        case mypage(onboardingEntity: OnboardingEntity)
         case emotion(emotion: Emotion)
     }
     
@@ -79,12 +78,15 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
         Task {
             do {
                 switch viewModelType {
-                case .onboarding(let onboardingChoices):
-                    try await fetchResultRecommendedRoutines(onboardingChoices: onboardingChoices)
-                case .mypage(let onboardingChoices):
-                    try await fetchResultRecommendedRoutines(onboardingChoices: onboardingChoices)
+                case .onboarding(let onboardingEntity):
+                    try await fetchResultRecommendedRoutines(onboardingEntity: onboardingEntity)
+
+                case .mypage(let onboardingEntity):
+                    try await fetchResultRecommendedRoutines(onboardingEntity: onboardingEntity)
+
                 case .emotion(let emotion):
                     try await fetchResultRecommendedRoutines(emotion: emotion)
+
                 case nil:
                     fatalError("ResultRecommendedRoutineViewModel Type이 설정되지 않았습니다.")
                 }
@@ -96,8 +98,8 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
     }
 
     // 온보딩 · 목표 선택지를 등록하고 그에 따른 추천 루틴 결과를 불러옵니다.
-    private func fetchResultRecommendedRoutines(onboardingChoices: [OnboardingChoiceType]) async throws {
-        let entities = try await resultRecommendedRoutineUseCase.fetchResultRecommendedRoutines(onboardingChoices: onboardingChoices)
+    private func fetchResultRecommendedRoutines(onboardingEntity: OnboardingEntity) async throws {
+        let entities = try await resultRecommendedRoutineUseCase.fetchResultRecommendedRoutines(onboardingEntity: onboardingEntity)
         let recommendedRoutines = entities.map({ $0.toRecommendedRoutine() })
         resultRecommendedRoutinesSubject.send([])
         resultRecommendedRoutinesSubject.send(recommendedRoutines)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

온보딩 및 목표 재설정 api를 v2와 연결하고, 약간의 UI를 수정했어요 ~

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://github.com/user-attachments/assets/309449e8-a684-446f-b8ee-a9269f561272


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- 온보딩 · 목표 재설정 api v2 연동
- 약간의 UI 수정 (UI 흐름 및 텍스트 등 ···)
- 토스트 뷰 (`NoticiationCenter` 썼으묘)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### 1. OnboardingDTO vs. OnboardingResponseDTO

```swift
struct OnboardingDTO: Encodable {
    let timeSlot: String
    let emotionType: [String]
    let realOutingFrequency: String?
    let targetOutingFrequency: String

    func toOnboardingEntity() -> OnboardingEntity {
        return OnboardingEntity(
            time: timeSlot,
            feeling: emotionType,
            outdoor: targetOutingFrequency)
    }
}
```

```swift
struct OnboardingResponseDTO: Decodable {
    let timeSlot: String
    let emotionTypes: [String]
    let targetOutingFrequency: String

    func toOnboardingEntity() -> OnboardingEntity {
        return OnboardingEntity(
            time: timeSlot,
            feeling: emotionTypes,
            outdoor: targetOutingFrequency)
    }
}
```

처음에는 `realOutingFrequency` 값이 옵셔널이니까 둘을 분리할 필요가 없을 것이라 생각했지만 ...   
유저 정보를 조회할 때(`OnboardingResponseDTO`)에는 감정 변수명이 `emotionTypes`로 오고,  
온보딩 값을 등록할 때(`OnboardingDTO`)에는 감정 변수명이 `emotionType`로 와서 분리할 수 밖에 없었습니다 ㅠㅠ !!!!


안드는 이미 수정해서 v2로 업로드 되어 있어서 바꿔달라고 말할 수 없었어요 ㅠ.ㅠ 


### 2. ToastView 

띵이 이전에 `ToastMessageView`를 너무너무 잘 만들어주셨는데요 !!!  
디자인 v2로 바꾸면서 2줄짜리 토스트 뷰가 필요 없어졌고, 그로 인해 `showToast()` 함수에서 width, height 등을 보내주는 것이 불필요해졌다고 생각이 들었습니다 !!!

그래서 딩이 했던 코드를 기반으로 `ToastView`를 만들었는데 기존 코드를 맘대로 바꾸는 것 같아 죄송하고 조심스러워서    
`ToastMessageView`를 삭제하는 대신 리뷰 노트에 의견 남겨봅니다 ㅠㅠ !!! 



## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #T3-183



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 맞춤 추천 루틴 변경 시 하단 토스트 알림이 표시됩니다.
  - 마이페이지에서 이전에 설정한 온보딩 결과를 불러와 확인할 수 있습니다.
- **Enhancements**
  - 온보딩 결과 화면이 진입 경로(온보딩/마이페이지)에 맞춰 동작 및 문구가 개선되었습니다.
  - 약관 동의 후 시작 흐름이 인트로 화면으로 단순화되었습니다.
  - 추천 루틴 결과 화면의 문구와 레이아웃이 가독성 있게 정비되었습니다.
- **Style**
  - 토스트 배경색 및 일부 버튼의 기본 색상이 일관된 회색 톤으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->