### PR TITLE
[Refactor-T3-187] 감정 구슬 등록 화면 · 추천 루틴 결과 화면 연결 

### DIFF
--- a/Projects/Presentation/Sources/EmotionRegister/View/EmotionRegisterCompletionViewController.swift
+++ b/Projects/Presentation/Sources/EmotionRegister/View/EmotionRegisterCompletionViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 이동현 on 8/23/25.
 //
 
+import Shared
 import SnapKit
 import UIKit
 
@@ -30,6 +31,7 @@ final class EmotionRegisterCompletionViewController: UIViewController {
         static let marbleImageTopSpacing: CGFloat = 96.92
     }
 
+    private let emotion: Emotion
     private let backgroundImageView = UIImageView()
     private let groundImageView = UIImageView()
     private let speechImageView = UIImageView()
@@ -40,6 +42,7 @@ final class EmotionRegisterCompletionViewController: UIViewController {
     private let pomoRightHandImageView = UIImageView()
 
     init(emotion: Emotion) {
+        self.emotion = emotion
         super.init(nibName: nil, bundle: nil)
 
         marbleImageView.image = emotion.image
@@ -57,11 +60,14 @@ final class EmotionRegisterCompletionViewController: UIViewController {
         super.viewDidLoad()
         configureAttribute()
         configureLayout()
+    }
 
-        // TODO: - 임시 네비 바 설정
-        configureCustomNavigationBar(navigationBarStyle: .withBackButton(title: "임시뒤로가기"))
-        let filteredNavigations = navigationController?.viewControllers.filter { !($0 is EmotionRegistrationViewController) } ?? []
-        navigationController?.setViewControllers(filteredNavigations, animated: false)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.goToRecommendedRoutineView()
+        }
     }
 
     func configureAttribute() {
@@ -135,5 +141,15 @@ final class EmotionRegisterCompletionViewController: UIViewController {
             make.top.equalTo(speechImageView.snp.top).offset(Layout.speechLabelTopSpacing)
             make.horizontalEdges.equalTo(speechImageView).inset(Layout.speechImageHorizontalSpacing)
         }
+    }
+
+    private func goToRecommendedRoutineView() {
+        guard let resultRecommendedRoutineViewModel = DIContainer.shared.resolve(type: ResultRecommendedRoutineViewModel.self)
+        else{ fatalError("resultRecommendedRoutineViewModel 의존성이 등록되지 않았습니다.") }
+
+        resultRecommendedRoutineViewModel.configure(viewModelType: .emotion(emotion: emotion))
+        let resultRecommendedRoutineView = ResultRecommendedRoutineViewController(entryPoint: .emotion, viewModel: resultRecommendedRoutineViewModel)
+        resultRecommendedRoutineView.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(resultRecommendedRoutineView, animated: true)
     }
 }

--- a/Projects/Presentation/Sources/MyPage/View/MypageView.swift
+++ b/Projects/Presentation/Sources/MyPage/View/MypageView.swift
@@ -41,6 +41,9 @@ final class MypageView: BaseViewController<MypageViewModel> {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = .white

--- a/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineViewController.swift
+++ b/Projects/Presentation/Sources/RecommendedRoutine/View/RecommendedRoutineViewController.swift
@@ -79,6 +79,7 @@ final class RecommendedRoutineViewController: BaseViewController<RecommendedRout
         routineLabel.textColor = BitnagilColor.gray60
 
         headerStackView.axis = .horizontal
+        registerEmotionButton.delegate = self
 
         levelButton.addAction(UIAction { _ in
             self.showBottomSheet()
@@ -299,6 +300,18 @@ final class RecommendedRoutineViewController: BaseViewController<RecommendedRout
 
     @objc private func tappedDimmedView() {
         toggleFloatingButton()
+    }
+}
+
+// MARK: RegisterEmotionButtonViewDelegate
+extension RecommendedRoutineViewController: RegisterEmotionButtonViewDelegate {
+    func registerEmotionButtonViewDidTapRegisterButton(_ sender: RegisterEmotionButtonView) {
+        guard let emotionRegisterViewModel = DIContainer.shared.resolve(type: EmotionRegisterViewModel.self)
+        else { fatalError("emotionRegisterViewModel 의존성이 등록되지 않았습니다.") }
+
+        let emotionRegistrationViewController = EmotionRegistrationViewController(viewModel: emotionRegisterViewModel)
+        emotionRegistrationViewController.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(emotionRegistrationViewController, animated: true)
     }
 }
 

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
@@ -37,8 +37,7 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
 
         var confirmButtonLabel: String {
             switch self {
-            case .onboarding: "등록하기"
-            case .mypage: "확인"
+            case .onboarding, .mypage: "등록하기"
             case .emotion: "맞춤 추천 루틴 보러 가기"
             }
         }
@@ -54,9 +53,9 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
 
         var isRoutineButtonEnabled: Bool {
             switch self {
-            case .onboarding, .emotion:
+            case .onboarding, .mypage:
                 true
-            case .mypage:
+            case .emotion:
                 false
             }
         }
@@ -132,7 +131,7 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
         case .onboarding, .mypage:
             configureCustomNavigationBar(navigationBarStyle: .withProgressBar(step: OnboardingType.allCases.count + 1))
         case .emotion:
-            configureCustomNavigationBar(navigationBarStyle: .withBackButton(title: ""))
+            configureCustomNavigationBar(navigationBarStyle: .withTitle(title: ""))
         }
 
         let mainLabelText = entryPoint.mainLabelText
@@ -216,9 +215,9 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
         case .onboarding:
             confirmButton = PrimaryButton(buttonState: .disabled, buttonTitle: entryPoint.confirmButtonLabel)
         case .mypage:
-            confirmButton = PrimaryButton(buttonState: .default, buttonTitle: entryPoint.confirmButtonLabel)
-        case .emotion:
             confirmButton = PrimaryButton(buttonState: .disabled, buttonTitle: entryPoint.confirmButtonLabel)
+        case .emotion:
+            confirmButton = PrimaryButton(buttonState: .default, buttonTitle: entryPoint.confirmButtonLabel)
         }
     }
 
@@ -312,20 +311,27 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
     }
 
     private func configureSkipButton() {
-        skipButton.addAction(UIAction { [weak self] _ in
-            guard let self else { return }
-            switch entryPoint {
-            case .emotion:
-                if let navigationController = self.navigationController {
-                    let viewControllers = navigationController.viewControllers
-                    if viewControllers.count >= 3 {
-                        navigationController.popToViewController(viewControllers[viewControllers.count - 3], animated: false)
+        skipButton.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                switch entryPoint {
+                case .emotion:
+                    if
+                        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                        let window = windowScene.windows.first(where: { $0.isKeyWindow }),
+                        let tabBarView = window.rootViewController as? TabBarView {
+                        self.navigationController?.popToRootViewController(animated: false)
+                        tabBarView.selectedIndex = 0
                     }
+
+                case .onboarding:
+                    goToNextView()
+
+                case .mypage:
+                    break
                 }
-            case .onboarding, .mypage:
-                goToNextView()
-            }
-        }, for: .touchUpInside)
+            },
+            for: .touchUpInside)
     }
 
     private func goToNextView() {
@@ -337,6 +343,9 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
             }
 
         case .mypage:
+            viewModel.action(input: .fetchSelectedRoutineId)
+
+        case .emotion:
             if
                 let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                 let window = windowScene.windows.first(where: { $0.isKeyWindow }),
@@ -345,16 +354,16 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
                 tabBarView.selectedIndex = 1
             }
             viewModel.action(input: .showRecommendedRoutineToastMessageView)
-
-        case .emotion:
-            viewModel.action(input: .fetchSelectedRoutineId)
         }
     }
 
     private func goToRoutineCreationView(routineId: Int) {
         guard let routineCreationViewModel = DIContainer.shared.resolve(type: RoutineCreationViewModel.self)
         else { fatalError("routineCreationViewModel 의존성이 등록되지 않았습니다.") }
-        let routineCreationView = RoutineCreationViewController(viewModel: routineCreationViewModel, recommendRoutineId: routineId)
+        let routineCreationView = RoutineCreationViewController(
+            viewModel: routineCreationViewModel,
+            recommendRoutineId: routineId,
+            isFromMypage: true)
         routineCreationView.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(routineCreationView, animated: true)
     }

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/ViewModel/ResultRecommendedRoutineViewModel.swift
@@ -128,7 +128,7 @@ final class ResultRecommendedRoutineViewModel: ViewModel {
         if selectedRoutines.contains(routine) {
             selectedRoutines.remove(routine)
         } else {
-            if case .emotion = viewModelType {
+            if case .mypage = viewModelType {
                 selectedRoutines.removeAll()
             }
             selectedRoutines.insert(routine)

--- a/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationViewController.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/View/RoutineCreationViewController.swift
@@ -67,6 +67,7 @@ final class RoutineCreationViewController: BaseViewController<RoutineCreationVie
     private let registerButton = UIButton()
     private let navigationTitle: String
     private let registerButtonTitle: String
+    private let isFromMypage: Bool
     private var cancellables = Set<AnyCancellable>()
 
     init(
@@ -75,6 +76,7 @@ final class RoutineCreationViewController: BaseViewController<RoutineCreationVie
     ) {
         navigationTitle = updateInfo?.routineId == nil ? "루틴 등록" : "루틴 수정"
         registerButtonTitle = updateInfo?.routineId == nil ? "등록하기" : "수정하기"
+        self.isFromMypage = false
 
         super.init(viewModel: viewModel)
 
@@ -85,9 +87,14 @@ final class RoutineCreationViewController: BaseViewController<RoutineCreationVie
         }
     }
 
-    init(viewModel: RoutineCreationViewModel, recommendRoutineId: Int) {
+    init(
+        viewModel: RoutineCreationViewModel,
+        recommendRoutineId: Int,
+        isFromMypage: Bool = false
+    ) {
         navigationTitle = "루틴 등록"
         registerButtonTitle = "등록하기"
+        self.isFromMypage = isFromMypage
 
         super.init(viewModel: viewModel)
 
@@ -136,8 +143,20 @@ final class RoutineCreationViewController: BaseViewController<RoutineCreationVie
         registerButton.titleLabel?.font = BitnagilFont.init(style: .body1, weight: .semiBold).font
         registerButton.addAction(
             UIAction { [weak self] _ in
-                self?.viewModel.action(input: .registerRoutine)
-                self?.navigationController?.popViewController(animated: true)
+                guard let self else { return }
+                self.viewModel.action(input: .registerRoutine)
+                if self.isFromMypage {
+                    if
+                        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                        let window = windowScene.windows.first(where: { $0.isKeyWindow }),
+                        let tabBarView = window.rootViewController as? TabBarView {
+                        self.navigationController?.popToRootViewController(animated: false)
+                        tabBarView.selectedIndex = 1
+                        viewModel.action(input: .showRecommendedRoutineToastMessageView)
+                    }
+                } else {
+                    self.navigationController?.popViewController(animated: true)
+                }
             },
             for: .touchUpInside)
         bindCreationCardViews()

--- a/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/ViewModel/RoutineCreationViewModel.swift
@@ -33,6 +33,7 @@ final class RoutineCreationViewModel: ViewModel {
         case configureEndDate(date: Date)
         case configureExecution(type: ExecutionTime)
         case registerRoutine
+        case showRecommendedRoutineToastMessageView
     }
 
     struct Output {
@@ -108,6 +109,8 @@ final class RoutineCreationViewModel: ViewModel {
             periodStartSubject.send(date)
         case .configureEndDate(let date):
             periodEndSubject.send(date)
+        case .showRecommendedRoutineToastMessageView:
+            showRecommendedRoutineToastMessageView()
         }
         
         updateIsRoutineValid()
@@ -277,6 +280,15 @@ final class RoutineCreationViewModel: ViewModel {
             } catch {
 
             }
+        }
+    }
+
+    private func showRecommendedRoutineToastMessageView() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            NotificationCenter.default.post(
+                name: .showRecommendedRoutineToast,
+                object: nil,
+                userInfo: nil)
         }
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

감정 구슬 등록 화면과 추천 루틴 결과 화면을 이어주고 감정 구슬 등록 api를 연동해주었어요 ~~        
또한 추천 루틴 결과 화면이 v1과 다르게 변경되어서 그것두 수정해주었답니다 ~  

<br>

## 📱 Screenshot

### 1. 온보딩

https://github.com/user-attachments/assets/970fb9d0-fbbb-40fe-84c7-a0e1a6964c1e


### 2. 목표 재설정


https://github.com/user-attachments/assets/455d142f-3ba6-4ced-a0aa-36d1ea3cf6c9


### 3. 감정 구슬 등록 

https://github.com/user-attachments/assets/64e6f298-8499-45ae-a258-d195540dcbb5


<br>

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- 감정 구슬 등록 화면 -> 추천 루틴 결과 화면 연결
- 감정 구슬 api 연동
- 추천 루틴 결과 화면 동작 요구사항에 맞게 수정

<br>

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

### 추천 루틴 결과 화면 동작 설명    

<img width="945" height="301" alt="스크린샷 2025-09-30 23 28 18" src="https://github.com/user-attachments/assets/6c830fdb-63de-4b4a-abfe-a6838e324f83" />

<img width="945" height="301" alt="스크린샷 2025-09-30 23 28 24" src="https://github.com/user-attachments/assets/7e082796-60c1-400f-9fe1-4031c5cfae6c" />

<br>

온보딩은 v1과 동일하지만 **목표 재설정**과 **감정 구슬 등록**이 서로 바뀌듯이 수정되었습니다 !!       
     
기존에는 **목표 재설정**에서는 루틴 선택이 불가능하고 확인 버튼을 통해 추천 루틴 화면으로 이동하는 것이었지만,    
수정된 v2에서는 1개의 루틴을 선택하고 루틴 등록 화면으로 이동해달라는 요구사항이 있었습니다.      

또한 **감정 구슬 등록**은 v1에서는 루틴 1개 선택 후 루틴 등록 화면으로 이동했었지만,    
수정된 v2에서는 루틴 선택 불가능하고 추천 루틴 결과 목록만 확인할 수 있도록 바뀌었습니다. 😭      

감정 구슬 등록 후 추천 루틴 결과 화면에서는 "맞춤 추천 보러가기" 버튼과 "건너뛰기" 버튼이 있습니다.    
각 버튼의 용도는 다음과 같습니다.       
- 맞춤 추천 보러가기: 추천 루틴 탭으로 이동
- 건너뛰기: 홈 탭으로 이동


다만 **감정 구슬 등록**은 2개의 경로로 진입할 수 있는데요 !! (홈, 추천 루틴 상단)  
어떠한 경로로 진입하든 버튼의 동작은 위에 기재한 것과 동일하게 해달라는 디자이너의 요청이 있었습니다 !!!  


혹시 흐름이 이해가 안되는 부분이 있다면 말씀해주세용 ~~  



<br>

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #T3-187



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 감정 등록 완료 후 1초 뒤 추천 루틴 화면으로 자동 이동.
  - 추천 루틴 화면에 감정 등록 진입 버튼 추가.
  - 루틴 생성 완료 시(마이페이지 경로) 루트로 복귀, 2번 탭 전환 및 토스트 노출.
- Refactor
  - 진입 경로별(온보딩/마이페이지/감정) 확인·건너뛰기 동작을 일관되게 정비: 탭 전환, 루트 이동, 토스트 표시.
  - 추천 루틴 화면의 버튼 라벨 및 초기 활성화 상태 조정.
  - 마이페이지 진입 시 내비게이션 바 항상 표시.
  - 추천 루틴 선택 규칙을 마이페이지 맥락에 맞게 조정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->