### PR TITLE
[Fix-T3-206] 탈퇴하기 기능 QA 이슈 수정

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,9 +17,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_16.4.app
 
       - name: Install Tuist
-        run: |
-          curl -Ls https://install.tuist.io | bash
-          echo "$HOME/.tuist/bin" >> $GITHUB_PATH
+        run: brew install tuist
 
       - name: Generate xcconfig
         run: |
@@ -40,5 +38,5 @@ jobs:
             -workspace Bitnagil.xcworkspace \
             -scheme App \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
-            clean build | xcpretty
+            -destination 'generic/platform=iOS Simulator' \
+            clean build

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,12 +16,10 @@ jobs:
       - name: Set Xcode version
         run: sudo xcode-select -s /Applications/Xcode_16.4.app
 
-      - name: Install Mise and Tuist
+      - name: Install Tuist
         run: |
-          curl -fsSL https://mise.jdx.dev/install.sh | sh
-          export PATH="$HOME/.local/bin:$PATH"
-          mise install tuist
-          mise use -g tuist
+          curl -Ls https://install.tuist.io | bash
+          echo "$HOME/.tuist/bin" >> $GITHUB_PATH
 
       - name: Generate xcconfig
         run: |
@@ -32,9 +30,8 @@ jobs:
 
       - name: Generate Xcode project with Tuist
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          mise exec -- tuist install
-          mise exec -- tuist generate --no-open
+          tuist install
+          tuist generate --no-open
 
       - name: Build with xcodebuild
         run: |
@@ -45,4 +42,3 @@ jobs:
             -sdk iphonesimulator \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
             clean build | xcpretty
-

--- a/Projects/Presentation/Sources/Common/Component/PrimaryButton.swift
+++ b/Projects/Presentation/Sources/Common/Component/PrimaryButton.swift
@@ -43,6 +43,7 @@ final class PrimaryButton: UIButton {
         self.buttonState = buttonState
         super.init(frame: .zero)
         configureAttribute(buttonTitle: buttonTitle)
+        self.isEnabled = buttonState != .disabled
     }
     
     required init?(coder: NSCoder) {

--- a/Projects/Presentation/Sources/Withdraw/View/WithdrawViewController.swift
+++ b/Projects/Presentation/Sources/Withdraw/View/WithdrawViewController.swift
@@ -63,6 +63,11 @@ final class WithdrawViewController: BaseViewController<WithdrawViewModel> {
         }
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        removeKeyboardNotification()
+    }
+
     private func updateConstraint() {
         let height = view.bounds.height
         if height <= 667 {
@@ -151,6 +156,8 @@ final class WithdrawViewController: BaseViewController<WithdrawViewModel> {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tapGesture.cancelsTouchesInView = false
         view.addGestureRecognizer(tapGesture)
+
+        configureKeyboardNotification()
     }
 
     override func configureLayout() {
@@ -301,14 +308,73 @@ final class WithdrawViewController: BaseViewController<WithdrawViewModel> {
         }
     }
 
+    private func configureKeyboardNotification() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillAppear),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillDisappear),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
+    }
+
+    private func removeKeyboardNotification() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil)
+
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
+    }
+
     @objc private func dismissKeyboard() {
         view.endEditing(true)
+    }
+    
+    @objc private func keyboardWillAppear(_ sender: Notification) {
+        guard
+            let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+            let duration = sender.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        let keyboardHeight = keyboardFrame.height
+        let buttonFrame = withdrawButton.convert(withdrawButton.bounds, to: view)
+        let buttonBottom = buttonFrame.maxY
+        let visibleHeight = view.frame.height - keyboardHeight
+
+        if buttonBottom > visibleHeight {
+            let offset = buttonBottom - visibleHeight + 50
+
+            UIView.animate(withDuration: duration) {
+                self.view.frame.origin.y = -offset
+            }
+        }
+    }
+
+    @objc private func keyboardWillDisappear(_ sender: Notification) {
+        guard let duration = sender.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
+        else { return }
+
+        UIView.animate(withDuration: duration) {
+            self.view.frame.origin.y = 0
+        }
     }
 }
 
 extension WithdrawViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         viewModel.action(input: .choiceWithdrawReason(reason: nil))
+
+        if !textView.text.isEmpty {
+            viewModel.action(input: .inputWithdrawReason(reason: textView.text))
+        }
     }
 
     func textViewDidChange(_ textView: UITextView) {

--- a/Projects/Presentation/Sources/Withdraw/View/WithdrawViewController.swift
+++ b/Projects/Presentation/Sources/Withdraw/View/WithdrawViewController.swift
@@ -40,7 +40,7 @@ final class WithdrawViewController: BaseViewController<WithdrawViewModel> {
     private let withdrawReasonView = UIView()
     private let withdrawReasonLabel = UILabel()
     private let withdrawReasonStackView = UIStackView()
-    private var withdrawButtons: [WithdrawReason: BitnagilChoiceButton] = [:]
+    private var withdrawReasonButtons: [WithdrawReason: BitnagilChoiceButton] = [:]
     private let withdrawReasonTextBackgroundView = UIView()
     private let withdrawReasonTextViewPlaceholder = UILabel()
     private let withdrawReasonTextView = UITextView()
@@ -121,7 +121,7 @@ final class WithdrawViewController: BaseViewController<WithdrawViewModel> {
                 make.height.equalTo(Layout.withdrawChoiceButtonHeight)
             }
             withdrawReasonStackView.addArrangedSubview(withdrawChoiceButton)
-            withdrawButtons[withdrawReason] = withdrawChoiceButton
+            withdrawReasonButtons[withdrawReason] = withdrawChoiceButton
         }
 
         withdrawReasonTextBackgroundView.backgroundColor = BitnagilColor.gray99
@@ -147,6 +147,10 @@ final class WithdrawViewController: BaseViewController<WithdrawViewModel> {
                 self?.viewModel.action(input: .withdrawService)
             },
             for: .touchUpInside)
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
     }
 
     override func configureLayout() {
@@ -284,7 +288,7 @@ final class WithdrawViewController: BaseViewController<WithdrawViewModel> {
     }
 
     private func updateWithdrawReason(selectedWithdrawReason: WithdrawReason?) {
-        withdrawButtons.forEach { withdrawReason in
+        withdrawReasonButtons.forEach { withdrawReason in
             let isSelected = withdrawReason.key == selectedWithdrawReason
             withdrawReason.value.updateButtonState(isChecked: isSelected)
         }
@@ -295,6 +299,10 @@ final class WithdrawViewController: BaseViewController<WithdrawViewModel> {
             withdrawReasonTextViewPlaceholder.isHidden = false
             withdrawReasonMaxLengthLabel.isHidden = true
         }
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
     }
 }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

QA에서 찾은 '탈퇴하기' 기능 관련 이슈들을 처리했어요 ~~~   


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

#### 1. 유의사항 확인 전, 탈퇴하기 버튼 비활성화
| Before | After |
|--------|--------|
| ![Simulator Screen Recording - iPhone 16 Pro - 2026-01-27 at 16 15 59](https://github.com/user-attachments/assets/8c9b9854-ec40-438e-b2ea-7256df0fbd72) | ![Simulator Screen Recording - iPhone 16 Pro - 2026-01-27 at 16 18 35](https://github.com/user-attachments/assets/d59b25b1-fe50-4820-b94e-714bddfa29ff) |

After에서 탈퇴하기 진짜 눌렀어유 근데 안되는것임 !!!! ㅎㅎ. ... 

#### 2. 탈퇴 사유 작성 시, 키보드에 가려지는 화면 offset 조정 
| Before | After |
|--------|--------|
| ![Simulator Screen Recording - iPhone 16 Pro - 2026-01-27 at 16 13 57](https://github.com/user-attachments/assets/a1a41f4f-a529-40dc-ad35-2e7ffbd9bb2e) | ![Simulator Screen Recording - iPhone 16 Pro - 2026-01-27 at 16 09 31](https://github.com/user-attachments/assets/837fb37b-d59f-4f2a-8ffe-e7b379d8604b) |


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- 유의사항 확인 전, 탈퇴하기 버튼 비활성화
- 탈퇴 사유 작성 시, 화면 클릭 시 키보드 내리기
- 탈퇴 사유 작성 시, 키보드에 가려지는 화면 offset 조정
- 탈퇴 사유 작성 후 다시 키보드 활성화 시 탈퇴하기 버튼이 비활성화 되는 버그 수정


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

댓쏘이지한 큐에이부터 ... 찬찬히 해치워나갈게유 ㅋ.ㅋ    
아자아자 파이팅 ~~ 


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #T3-206



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 출금 화면에서 키보드가 표시될 때 버튼 접근성이 개선되었습니다.
  * 화면 탭으로 키보드를 해제할 수 있도록 개선되었습니다.
  * 텍스트 입력 시 키보드 표시/숨김 동작이 더 안정적으로 동작합니다.
  * 화면 전환 시 키보드 상태 관리가 개선되어 예기치 않은 레이아웃 이동이 줄어듭니다.
  * 버튼 초기 활성화 상태가 논리적으로 일치하도록 조정되어 동작 일관성이 향상되었습니다

* **잡무(Chores)**
  * 빌드/테스트 워크플로우 설정이 간소화되어 빌드 절차가 정리되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->