### PR TITLE
[Fix] 감정등록 화면 QA 대응 (무한 스크롤 끊김, 스크롤 가능 영역 확장)

### DIFF
--- a/Projects/Presentation/Sources/EmotionRegister/View/EmotionCollectionViewLayout.swift
+++ b/Projects/Presentation/Sources/EmotionRegister/View/EmotionCollectionViewLayout.swift
@@ -8,8 +8,12 @@
 import UIKit
 
 final class EmotionCollectionViewLayout: UICollectionViewFlowLayout {
-    private let itemWidthRatio: CGFloat = 0.5
-    private let lineSpacing: CGFloat = 16
+    private enum Layout {
+        static let itemWidthRatio: CGFloat = 0.5
+        static let lineSpacing: CGFloat = 16
+        static let bottomSpacing: CGFloat = 100
+    }
+
     private var baseDistance: CGFloat { itemSize.width + minimumLineSpacing }
 
     override class var layoutAttributesClass: AnyClass { EmotionCollectionViewLayoutAttributes.self }
@@ -19,14 +23,18 @@ final class EmotionCollectionViewLayout: UICollectionViewFlowLayout {
         guard let collectionView else { return }
 
         scrollDirection = .horizontal
-        minimumLineSpacing = lineSpacing
+        minimumLineSpacing = Layout.lineSpacing
 
-        let itemWidth = floor(collectionView.bounds.width * itemWidthRatio)
-        let itemHeight = collectionView.bounds.height
+        let itemWidth = floor(collectionView.bounds.width * Layout.itemWidthRatio)
+        let itemHeight = collectionView.bounds.height - Layout.bottomSpacing
         itemSize = CGSize(width: itemWidth, height: itemHeight)
 
         let insetX = (collectionView.bounds.width - itemWidth) / 2
-        sectionInset = UIEdgeInsets(top: 0, left: insetX, bottom: 0, right: insetX)
+        sectionInset = UIEdgeInsets(
+            top: 0,
+            left: insetX,
+            bottom: Layout.bottomSpacing,
+            right: insetX)
 
         collectionView.decelerationRate = .fast
     }
@@ -74,5 +82,15 @@ final class EmotionCollectionViewLayout: UICollectionViewFlowLayout {
 
     override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
         return true
+    }
+
+    func fetchcurrentIndex() -> Int? {
+        guard let collectionView else { return nil }
+        
+        let centerX = collectionView.contentOffset.x + (collectionView.bounds.width / 2)
+        let insetX = (collectionView.bounds.width - itemSize.width) / 2
+        
+        let relativeX = centerX - insetX
+        return Int(round(relativeX / baseDistance))
     }
 }

--- a/Projects/Presentation/Sources/EmotionRegister/View/EmotionRegistrationViewController.swift
+++ b/Projects/Presentation/Sources/EmotionRegister/View/EmotionRegistrationViewController.swift
@@ -62,7 +62,6 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
     private var isMarbleHeld = false
     private var marbleImageViewMidY: CGFloat?
     private var marbleImageViewPanGesture: UIPanGestureRecognizer?
-    private var infoSwipeOverlayViewPanGesturePanGesture: UIPanGestureRecognizer?
     private var emotion: Emotion?
     private var dataSource: UICollectionViewDiffableDataSource<Int, Emotion>?
     private var cancellables: Set<AnyCancellable>
@@ -130,7 +129,6 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
 
         infoSwipeOverlayView.backgroundColor = .clear
         infoSwipeOverlayView.isUserInteractionEnabled = false
-        infoSwipeOverlayView.backgroundColor = .clear
 
         infoLabel.numberOfLines = 0
         infoLabel.font = BitnagilFont.init(style: .body2, weight: .medium).font
@@ -286,7 +284,7 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
 
                 let originalEmotionCount = emotions.count
                 let centerIndex = itemSetCount / 2 + 1
-                let multipliedEmotions = (0..<7).flatMap { i in
+                let multipliedEmotions = (0..<itemSetCount).flatMap { i in
                     i == centerIndex ? emotions : emotions.map { $0.copy() }
                 }
 
@@ -296,7 +294,6 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
                 else { return }
 
                 lastMarbleCellIndex = currentIndex
-                print(lastMarbleCellIndex)
 
                 var snapshot = NSDiffableDataSourceSnapshot<Int, Emotion>()
                 snapshot.appendSections([0])

--- a/Projects/Presentation/Sources/EmotionRegister/View/EmotionRegistrationViewController.swift
+++ b/Projects/Presentation/Sources/EmotionRegister/View/EmotionRegistrationViewController.swift
@@ -18,7 +18,7 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
         static let smallMarbleImageSize: CGFloat = 40
         static let emotionLabelWidth: CGFloat = 92
         static let emotionLabelHeight: CGFloat = 36
-        static let emotionCollectionViewHeight: CGFloat = 191
+        static let emotionCollectionViewHeight: CGFloat = 291
         static let emotionMarbleImageViewSize: CGFloat = 140
         static let emotionMarbleImageViewTopSpacing: CGFloat = 13
         static let speechImageTopSpacing: CGFloat = 26
@@ -33,11 +33,12 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
         static let foromThumbLeadingSpacing: CGFloat = 71
         static let handMarbleImageViewBottomSpacing: CGFloat = 7
         static let handMarbleImageViewTopSpacing: CGFloat = 50
-        static let infoLabelTopSpacing: CGFloat = 30
+        static let infoLabelTopSpacing: CGFloat = -70
         static let doubleChevronIconSize: CGFloat = 24
         static let doubleChevronIconHorizontalSpacing: CGFloat = 26
         static let doubleChevronIconTopSpacing: CGFloat = 10
         static let infoViewSize: CGFloat = 0
+        static let infoSwipeOverlayViewHeight = 100
     }
 
     private let smallMarbleScrollView = UIScrollView()
@@ -55,14 +56,20 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
     private let leftDoubleChevronImageView = UIImageView()
     private let rightDoubleChevronImageView = UIImageView()
     private let downDoubleChevronImageView = UIImageView()
+    private let infoSwipeOverlayView = UIView()
+    private let hapticGenerator = UISelectionFeedbackGenerator()
+    private let itemSetCount = 7
     private var isMarbleHeld = false
     private var marbleImageViewMidY: CGFloat?
     private var marbleImageViewPanGesture: UIPanGestureRecognizer?
+    private var infoSwipeOverlayViewPanGesturePanGesture: UIPanGestureRecognizer?
     private var emotion: Emotion?
     private var dataSource: UICollectionViewDiffableDataSource<Int, Emotion>?
     private var cancellables: Set<AnyCancellable>
+    private var lastMarbleCellIndex: Int = 0
+    
     var itemCount: Int {
-        return (dataSource?.snapshot().numberOfItems ?? 0) / 3
+        return (dataSource?.snapshot().numberOfItems ?? 0) / itemSetCount
     }
 
 
@@ -121,6 +128,10 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
         speechLabel.font = BitnagilFont.init(style:.cafe24Title2, weight: .light).font
         speechLabel.textColor = .clear
 
+        infoSwipeOverlayView.backgroundColor = .clear
+        infoSwipeOverlayView.isUserInteractionEnabled = false
+        infoSwipeOverlayView.backgroundColor = .clear
+
         infoLabel.numberOfLines = 0
         infoLabel.font = BitnagilFont.init(style: .body2, weight: .medium).font
         infoLabel.textColor = BitnagilColor.gray50
@@ -160,6 +171,7 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
         view.addSubview(handMarbleView)
         view.addSubview(thumbImageView)
         view.addSubview(infoView)
+        view.addSubview(infoSwipeOverlayView)
         smallMarbleScrollView.addSubview(smallMarbleStackView)
         infoView.addSubview(infoLabel)
         infoView.addSubview(leftDoubleChevronImageView)
@@ -258,6 +270,12 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
             make.bottom.equalTo(thumbImageView.snp.bottom).offset(-Layout.handMarbleImageViewBottomSpacing)
             make.size.equalTo(Layout.emotionMarbleImageViewSize)
         }
+
+        infoSwipeOverlayView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview()
+            make.bottom.equalTo(emotionCollectionView.snp.bottom)
+            make.height.equalTo(Layout.infoSwipeOverlayViewHeight)
+        }
     }
 
     override func bind() {
@@ -267,11 +285,22 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
                 guard let self = self else { return }
 
                 let originalEmotionCount = emotions.count
-                let tripledEmotions = emotions.map({ $0.copy() }) + emotions + emotions.map({ $0.copy() })
+                let centerIndex = itemSetCount / 2 + 1
+                let multipliedEmotions = (0..<7).flatMap { i in
+                    i == centerIndex ? emotions : emotions.map { $0.copy() }
+                }
+
+                guard
+                    let layout = emotionCollectionView.collectionViewLayout as? EmotionCollectionViewLayout,
+                    let currentIndex = layout.fetchcurrentIndex()
+                else { return }
+
+                lastMarbleCellIndex = currentIndex
+                print(lastMarbleCellIndex)
 
                 var snapshot = NSDiffableDataSourceSnapshot<Int, Emotion>()
                 snapshot.appendSections([0])
-                snapshot.appendItems(tripledEmotions)
+                snapshot.appendItems(multipliedEmotions)
                 self.dataSource?.apply(snapshot, animatingDifferences: false)
 
                 self.scrollToIndex(index: originalEmotionCount)
@@ -350,8 +379,7 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
     }
 
     private func configureMarbleImageView() {
-        marbleImageViewPanGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(gesture:)))
-        marbleImageViewPanGesture?.cancelsTouchesInView = false
+        marbleImageViewPanGesture = UIPanGestureRecognizer(target: self, action: #selector(handleEmotionCollectionViewPanning(gesture:)))
 
         handMarbleView.layer.cornerRadius = Layout.emotionMarbleImageViewSize / 2
         handMarbleView.layer.masksToBounds = true
@@ -377,7 +405,7 @@ final class EmotionRegistrationViewController: BaseViewController<EmotionRegiste
         }
     }
 
-    @objc private func handlePan(gesture: UIPanGestureRecognizer) {
+    @objc private func handleEmotionCollectionViewPanning(gesture: UIPanGestureRecognizer) {
         guard let marbleImageViewMidY else { return }
 
         switch gesture.state {
@@ -454,8 +482,22 @@ extension EmotionRegistrationViewController: UICollectionViewDelegate {
 }
 
 extension EmotionRegistrationViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard
+            let layout = emotionCollectionView.collectionViewLayout as? EmotionCollectionViewLayout,
+            let currentIndex = layout.fetchcurrentIndex(),
+            lastMarbleCellIndex != currentIndex
+        else { return }
+
+        lastMarbleCellIndex = currentIndex
+        hapticGenerator.selectionChanged()
+        hapticGenerator.prepare()
+
+    }
+
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         emotionMarbleImageView.isHidden = true
+        hapticGenerator.prepare()
     }
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
@@ -470,7 +512,7 @@ extension EmotionRegistrationViewController: UIScrollViewDelegate {
         else { return }
 
         let index = indexPath.row % itemCount
-        if indexPath.row < itemCount / 3 || indexPath.row >= itemCount * 2 / 3 {
+        if indexPath.row < itemCount / itemSetCount || indexPath.row >= itemCount * (itemSetCount / 2 + 1) / itemSetCount {
             scrollToIndex(index: index)
         }
         viewModel.action(input: .selectEmotion(index: index))


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 감정구슬 관련 QA 대응을 진행했습니다!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- UI 변경사항 없음

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- [구슬 스와이프 가능 영역 확대](https://www.notion.so/friendshipportfolio/QA-2edf330eead581aa8ef4f785ec76ce14?p=2f1f330eead58056b75bf67ee54b9886&pm=s)
- [무한 스크롤 끊김 현상](https://www.notion.so/friendshipportfolio/QA-2edf330eead581aa8ef4f785ec76ce14?p=2f2f330eead580dd986ceccd083e54d4&pm=s)
- 추가로, 구슬 스크롤 시, 햅틱 피드백을 통해 사용자 경험을 향상시키고자 했습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리즈 노트

* **새로운 기능**
  * 감정 컬렉션 뷰 높이 확대로 더 넓은 표시 영역 제공
  * 스와이프 안내 오버레이 추가하여 사용성 향상
  * 스크롤 중 중앙 항목 인덱스 계산 및 이에 따른 햅틱 피드백 도입
  * 아이템 세트 수 기반의 유동적 페이징 지원

* **개선 사항**
  * 레이아웃 상수 정리로 디자인 일관성 강화
  * 스크롤 스냅 및 제스처 처리 로직 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->