### PR TITLE
[Fix-T3-207] 루틴 삭제하기 기능 QA 이슈 수정 

### DIFF
--- a/Projects/Presentation/Sources/Common/Component/RoutineCardView.swift
+++ b/Projects/Presentation/Sources/Common/Component/RoutineCardView.swift
@@ -235,13 +235,15 @@ final class RoutineCardView: UIView {
         }
 
         if let _ = routine as? Routine {
-            addSubview(editButton)
             addSubview(deleteButton)
 
-            editButton.snp.makeConstraints { make in
-                make.top.equalToSuperview().offset(Layout.plusButtonTopSpacing)
-                make.trailing.equalTo(deleteButton).offset(-Layout.editButtonTrailingSpacing)
-                make.size.equalTo(Layout.plusButtonSize)
+            if !routine.isDeleted {
+                addSubview(editButton)
+                editButton.snp.makeConstraints { make in
+                    make.top.equalToSuperview().offset(Layout.plusButtonTopSpacing)
+                    make.trailing.equalTo(deleteButton).offset(-Layout.editButtonTrailingSpacing)
+                    make.size.equalTo(Layout.plusButtonSize)
+                }
             }
 
             deleteButton.snp.makeConstraints { make in

--- a/Projects/Presentation/Sources/Common/Component/ToastView.swift
+++ b/Projects/Presentation/Sources/Common/Component/ToastView.swift
@@ -17,7 +17,7 @@ final class ToastView: UIView {
 
     private let checkIcon = UIImageView()
     private let messageLabel = UILabel()
-    private let message: String
+    private var message: String
 
     init(message: String) {
         self.message = message
@@ -62,7 +62,12 @@ final class ToastView: UIView {
         }
     }
 
-    func showToastMessageView() {
+    func showToastMessageView(message: String? = nil) {
+        if let message {
+            self.message = message
+            self.messageLabel.text = message
+        }
+
         alpha = 0
         isHidden = false
 

--- a/Projects/Presentation/Sources/Common/Extension/Notification+.swift
+++ b/Projects/Presentation/Sources/Common/Extension/Notification+.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification.Name {
     static let showRecommendedRoutineToast = Notification.Name("showRecommendedRoutineToast")
+    static let showDeletedRoutineToast = Notification.Name("showDeletedRoutineToast")
 }

--- a/Projects/Presentation/Sources/Common/Protocol/RoutineProtocol.swift
+++ b/Projects/Presentation/Sources/Common/Protocol/RoutineProtocol.swift
@@ -11,4 +11,5 @@ protocol RoutineProtocol {
     var title: String { get }
     var routineType: RoutineCategoryType? { get }
     var subRoutines: [String] { get }
+    var isDeleted: Bool { get }
 }

--- a/Projects/Presentation/Sources/Onboarding/Model/RecommendedRoutine.swift
+++ b/Projects/Presentation/Sources/Onboarding/Model/RecommendedRoutine.swift
@@ -15,6 +15,7 @@ public struct RecommendedRoutine: BitnagilChoiceProtocol, RoutineProtocol, Hasha
     let routineCategory: RoutineCategoryType
     let routineType: RoutineCategoryType?
     let routineLevel: RoutineLevelType
+    let isDeleted: Bool
 
     init(
         id: Int,
@@ -32,6 +33,7 @@ public struct RecommendedRoutine: BitnagilChoiceProtocol, RoutineProtocol, Hasha
         self.routineCategory = routineCategory
         self.routineType = routineType
         self.routineLevel = routineLevel
+        self.isDeleted = false
     }
 }
 

--- a/Projects/Presentation/Sources/RoutineList/View/RoutineListViewController.swift
+++ b/Projects/Presentation/Sources/RoutineList/View/RoutineListViewController.swift
@@ -242,7 +242,7 @@ extension RoutineListViewController: RoutineCardViewDelegate {
         view.addSubview(newDimmedView)
         dimmedView = newDimmedView
 
-        if routine.repeatDay.isEmpty {
+        if routine.repeatDay.isEmpty || routine.isDeleted {
             let routineDeleteAlertViewController = RoutineDeleteAlertViewController(viewModel: viewModel, isDeleteAllRoutines: false)
             if let sheet = routineDeleteAlertViewController.sheetPresentationController {
                 sheet.prefersGrabberVisible = false

--- a/Projects/Presentation/Sources/RoutineList/View/RoutineListViewController.swift
+++ b/Projects/Presentation/Sources/RoutineList/View/RoutineListViewController.swift
@@ -20,6 +20,8 @@ final class RoutineListViewController: BaseViewController<RoutineListViewModel> 
         static let routineScrollViewTopSpacing: CGFloat = 16
         static let routineStackViewSpacing: CGFloat = 12
         static let routineStackViewBottomSpacing: CGFloat = 60
+        static let toastMessageViewHeight: CGFloat = 52
+        static let toastMessageViewBottomSpacing: CGFloat = 20
     }
 
     private let weekView: WeekView
@@ -27,6 +29,8 @@ final class RoutineListViewController: BaseViewController<RoutineListViewModel> 
     private let routineScrollView = UIScrollView()
     private let routineStackView = UIStackView()
     private var routineCardViews: [String: RoutineCardView] = [:]
+    private let deleteToastMessage: String = "삭제가 완료되었습니다."
+    private var toastMessageView = ToastView(message: "")
     private var dimmedView: UIView?
     private var cancellables: Set<AnyCancellable>
 
@@ -79,6 +83,7 @@ final class RoutineListViewController: BaseViewController<RoutineListViewModel> 
         view.addSubview(emptyView)
         view.addSubview(routineScrollView)
         routineScrollView.addSubview(routineStackView)
+        view.addSubview(toastMessageView)
 
         weekView.snp.makeConstraints { make in
             make.top.equalTo(safeArea).offset(Layout.weekViewTopSpacing)
@@ -104,6 +109,13 @@ final class RoutineListViewController: BaseViewController<RoutineListViewModel> 
             make.bottom.equalToSuperview().inset(Layout.routineStackViewBottomSpacing)
             make.width.equalTo(routineScrollView.snp.width)
         }
+        
+        toastMessageView.snp.makeConstraints { make in
+            make.leading.equalTo(safeArea).offset(Layout.horizontalMargin)
+            make.trailing.equalTo(safeArea).inset(Layout.horizontalMargin)
+            make.height.equalTo(Layout.toastMessageViewHeight)
+            make.bottom.equalTo(safeArea).inset(Layout.toastMessageViewBottomSpacing)
+        }
     }
 
     override func bind() {
@@ -127,6 +139,14 @@ final class RoutineListViewController: BaseViewController<RoutineListViewModel> 
             .receive(on: DispatchQueue.main)
             .sink { [weak self] routines in
                 self?.updateRoutineStackView(routines: routines)
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .showDeletedRoutineToast)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.toastMessageView.showToastMessageView(message: deleteToastMessage)
             }
             .store(in: &cancellables)
     }

--- a/Projects/Presentation/Sources/RoutineList/ViewModel/RoutineListViewModel.swift
+++ b/Projects/Presentation/Sources/RoutineList/ViewModel/RoutineListViewModel.swift
@@ -118,9 +118,19 @@ final class RoutineListViewModel: ViewModel {
                 }
                 deleteRoutineResultSubject.send(true)
                 fetchRoutines()
+                showDeletedRoutineToastMessageView()
             } catch {
                 deleteRoutineResultSubject.send(false)
             }
+        }
+    }
+
+    private func showDeletedRoutineToastMessageView() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            NotificationCenter.default.post(
+                name: .showDeletedRoutineToast,
+                object: nil,
+                userInfo: nil)
         }
     }
 }

--- a/Projects/Presentation/Sources/RoutineList/ViewModel/RoutineListViewModel.swift
+++ b/Projects/Presentation/Sources/RoutineList/ViewModel/RoutineListViewModel.swift
@@ -73,6 +73,8 @@ final class RoutineListViewModel: ViewModel {
                 let endDateString = endDate.convertToString(dateType: .yearMonthDate)
 
                 let routinesDictionary = try await routineRepository.fetchRoutines(from: startDateString, to: endDateString)
+
+                self.routines.removeAll()
                 for dailyRoutine in routinesDictionary {
                     let date = dailyRoutine.key
                     let routine = dailyRoutine.value.routines.map({ $0.toRoutine() })


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

루틴 삭제하기 기능 관련 QA 대응했어용 ~~

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

#### 1. 당일 루틴 삭제 후 토스트 메시지 확인
| 당일 루틴 삭제 | 
|--------|
| ![당일 루틴 삭제](https://github.com/user-attachments/assets/f0c9f619-e562-4e24-a03e-deca049b0bbb) | 

- 당일 루틴 (반복 x) 삭제 시, 바로 삭제에 관련한 확인 창 뜸
- 삭제 완료 시, 해당 루틴은 삭제되고 토스트 메시지 뷰가 표시됨


#### 2. 반복 루틴 삭제 후 토스트 메시지 · 루틴 상태 확인
| 반복 루틴 삭제 | 
|--------|
| ![Simulator Screen Recording - iPhone 16 Pro - 2026-02-06 at 17 47 56](https://github.com/user-attachments/assets/6149f8ec-8c1d-4ee6-9bde-b05a2dabaca7) | 

- 기존 2월 2일 ~ 2월 13일까지 월, 수, 금 반복 설정된 루틴이 존재함
- 이때 6일에서 루틴을 반복 삭제할 경우, 그 이후 루틴들(2월 9일 ~ 2월 13일)은 바로 삭제되고 이전 루틴들은 수정 버튼이 사라짐
- 기존에 남아있는 루틴(2월 2일 ~ 2월 6일)을 다시 삭제할 경우 반복 루틴이 아닌 당일 루틴으로 인식되고 루틴을 삭제할 수 있음
- 토스트 메시지도 잘 표시됨


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- ToastView show 함수 확장 (추후 루틴 수정 토스트 메시지 대비)
- 루틴 삭제 후 토스트 메시지 띄우기
- 삭제된 루틴에 대하여 수정 버튼 없애기
- 삭제된 루틴에 대하여 반복 루틴 삭제 기능 막기


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #T3-207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 루틴 삭제 시 사용자에게 확인 메시지를 표시하는 토스트 UI 추가
  * 토스트 메시지 내용 동적 업데이트 기능 지원

* **개선 사항**
  * 삭제된 루틴에 대해 편집 버튼을 숨기는 처리 추가
  * 루틴 목록 조회 시마다 기존 캐시 데이터 초기화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->