### PR TITLE
[Fix] 제보하기 QA 대응 (2차)

### DIFF
--- a/Projects/Presentation/Sources/Report/View/Component/ReportHistory/ReportHistoryEmptyView.swift
+++ b/Projects/Presentation/Sources/Report/View/Component/ReportHistory/ReportHistoryEmptyView.swift
@@ -54,7 +54,7 @@ final class ReportHistoryEmptyView: UIView {
 
         labelStackView.snp.makeConstraints { make in
             make.center.equalToSuperview()
-            make.height.equalTo(Layout.stackViewHeight)
+            make.height.equalTo(Layout.stackViewHeight).priority(.medium)
             make.width.equalTo(Layout.stackViewWidth)
         }
 

--- a/Projects/Presentation/Sources/Report/View/Component/ReportHistory/ReportHistoryTableViewCell.swift
+++ b/Projects/Presentation/Sources/Report/View/Component/ReportHistory/ReportHistoryTableViewCell.swift
@@ -55,6 +55,7 @@ final class ReportHistoryTableViewCell: UITableViewCell {
         photoImageView.layer.cornerRadius = 9.25
         photoImageView.layer.masksToBounds = true
 
+        titleLabel.numberOfLines = 2
         titleLabel.textColor = BitnagilColor.gray10
         titleLabel.font = BitnagilFont.init(style: .body2, weight: .semiBold).font
         titleLabel.textAlignment = .left
@@ -93,9 +94,14 @@ final class ReportHistoryTableViewCell: UITableViewCell {
         }
 
         photoImageView.snp.makeConstraints { make in
-            make.verticalEdges
+            make.top
                 .equalToSuperview()
                 .inset(Layout.verticalSpacing)
+
+            make.bottom
+                .equalToSuperview()
+                .inset(Layout.verticalSpacing)
+                .priority(.low)
 
             make.trailing
                 .equalToSuperview()
@@ -130,6 +136,7 @@ final class ReportHistoryTableViewCell: UITableViewCell {
             make.bottom
                 .equalToSuperview()
                 .offset(-Layout.verticalSpacing)
+                .priority(.medium)
 
             make.width
                 .equalTo(Layout.categoryLabelWidth)

--- a/Projects/Presentation/Sources/Report/View/ReportDetailViewController.swift
+++ b/Projects/Presentation/Sources/Report/View/ReportDetailViewController.swift
@@ -152,6 +152,7 @@ class ReportDetailViewController: BaseViewController<ReportDetailViewModel> {
         titleLabel.text = reportDetailContentType.title
         titleLabel.font = BitnagilFont(style: .body2, weight: .semiBold).font
         titleLabel.textColor = BitnagilColor.gray10
+        titleLabel.numberOfLines = 2
 
         backgroudView.layer.masksToBounds = true
         backgroudView.layer.cornerRadius = 12

--- a/Projects/Presentation/Sources/Report/View/ReportRegistrationViewController.swift
+++ b/Projects/Presentation/Sources/Report/View/ReportRegistrationViewController.swift
@@ -44,8 +44,8 @@ final class ReportRegistrationViewController: BaseViewController<ReportRegistrat
         static let registerButtonHeight: CGFloat = 54
         static let categoryBottomSheetHeight: CGFloat = 362
         static let cameraBottomSheetHeight: CGFloat = 174
-        static let contentCountLabelTopSpacing: CGFloat = 6
-        static let contentCountLabelHeight: CGFloat = 18
+        static let countLabelTopSpacing: CGFloat = 6
+        static let countLabelHeight: CGFloat = 18
     }
 
     private typealias Section = ReportRegistrationViewController.CollectionViewSection
@@ -62,12 +62,16 @@ final class ReportRegistrationViewController: BaseViewController<ReportRegistrat
     private let cameraButton = ReportCameraButton(frame: .zero)
     private let photoCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
     private let categoryTextView = ReportTextView(type: .combo, placeholder: "카테고리 선택")
-    private let reportTitleTextView = ReportTextView(type: .editable, placeholder: "제보 제목을 작성해주세요.")
+    private let reportTitleTextView = ReportTextView(
+        type: .editable,
+        placeholder: "제보 제목을 작성해주세요."
+        ,maxLength: 50)
     private let reportContentTextView = ReportTextView(
         type: .editable,
         placeholder: "어떤 위험인지 간단히 설명해주세요.",
         maxLength: 150)
     private let locationTextView = ReportTextView(type: .nonEditable, placeholder: "현재 위치 검색")
+    private let titleCountLabel = UILabel()
     private let contentTextCountLabel = UILabel()
     private let locationButton = LocationButton()
     private let registerButton = PrimaryButton(buttonState: .disabled, buttonTitle: "제출하기")
@@ -127,6 +131,9 @@ final class ReportRegistrationViewController: BaseViewController<ReportRegistrat
             },
             for: .touchUpInside)
 
+        titleCountLabel.font = BitnagilFont.init(style: .caption1, weight: .medium).font
+        titleCountLabel.textColor = BitnagilColor.gray80
+
         contentTextCountLabel.font = BitnagilFont.init(style: .caption1, weight: .medium).font
         contentTextCountLabel.textColor = BitnagilColor.gray80
 
@@ -148,6 +155,7 @@ final class ReportRegistrationViewController: BaseViewController<ReportRegistrat
         scrollContentView.addSubview(collectionViewTitleLabel)
         scrollContentView.addSubview(categoryTitleLabel)
         scrollContentView.addSubview(nameTitleLabel)
+        scrollContentView.addSubview(titleCountLabel)
         scrollContentView.addSubview(contentTitleLabel)
         scrollContentView.addSubview(locationTitleLabel)
         scrollContentView.addSubview(cameraButton)
@@ -238,9 +246,20 @@ final class ReportRegistrationViewController: BaseViewController<ReportRegistrat
                 .equalTo(Layout.textViewHeight)
         }
 
-        categoryTitleLabel.snp.makeConstraints { make in
+        titleCountLabel.snp.makeConstraints { make in
             make.top
                 .equalTo(reportTitleTextView.snp.bottom)
+                .offset(Layout.countLabelTopSpacing)
+
+            make.height
+                .equalTo(Layout.countLabelHeight)
+
+            make.trailing.equalTo(reportTitleTextView)
+        }
+
+        categoryTitleLabel.snp.makeConstraints { make in
+            make.top
+                .equalTo(titleCountLabel.snp.bottom)
                 .offset(Layout.titleLabelTopSpacing)
 
             make.leading
@@ -294,13 +313,13 @@ final class ReportRegistrationViewController: BaseViewController<ReportRegistrat
         contentTextCountLabel.snp.makeConstraints { make in
             make.top
                 .equalTo(reportContentTextView.snp.bottom)
-                .offset(Layout.contentCountLabelTopSpacing)
+                .offset(Layout.countLabelTopSpacing)
 
             make.trailing
                 .equalToSuperview()
                 .offset(-Layout.horizontalInset)
 
-            make.height.equalTo(Layout.contentCountLabelHeight)
+            make.height.equalTo(Layout.countLabelHeight)
         }
 
         locationTitleLabel.snp.makeConstraints { make in
@@ -374,17 +393,22 @@ final class ReportRegistrationViewController: BaseViewController<ReportRegistrat
         viewModel.output.titlePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] title in
-                self?.reportTitleTextView.configure(text: title ?? "")
+                guard let self else { return }
+
+                self.reportTitleTextView.configure(text: title ?? "")
+                let title = title ?? ""
+                self.titleCountLabel.text = "\(title.count) / \(viewModel.output.maxTitleLength)"
             }
             .store(in: &cancellables)
 
         viewModel.output.contentPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] content in
-                self?.reportContentTextView.configure(text: content ?? "")
+                guard let self else { return }
+                self.reportContentTextView.configure(text: content ?? "")
 
                 let content = content ?? ""
-                self?.contentTextCountLabel.text = "\(content.count) / 150"
+                self.contentTextCountLabel.text = "\(content.count) / \(viewModel.output.maxContentLength)"
             }
             .store(in: &cancellables)
 

--- a/Projects/Presentation/Sources/Report/ViewModel/ReportRegistrationViewModel.swift
+++ b/Projects/Presentation/Sources/Report/ViewModel/ReportRegistrationViewModel.swift
@@ -32,6 +32,8 @@ final class ReportRegistrationViewModel: ViewModel {
         let exceptionPublisher: AnyPublisher<String, Never>
         let reportRegistrationCompletePublisher: AnyPublisher<Int?, Never>
         let maxPhotoCount: Int
+        let maxContentLength: Int
+        let maxTitleLength: Int
     }
 
     private(set) var output: Output
@@ -46,6 +48,8 @@ final class ReportRegistrationViewModel: ViewModel {
     private let reportRegistrationCompleteSubject = PassthroughSubject<Int?, Never>()
     private let exceptionSubject = PassthroughSubject<String, Never>()
     private let maxPhotoCount = 3
+    private let maxContentLength = 150
+    private let maxTitleLength = 50
     private var location: LocationEntity? = nil
     private(set) var selectedReportType: ReportType?
     var selectedPhotoCount: Int {
@@ -65,7 +69,9 @@ final class ReportRegistrationViewModel: ViewModel {
             isReportValid: reportVerificationSubject.eraseToAnyPublisher(),
             exceptionPublisher: exceptionSubject.eraseToAnyPublisher(),
             reportRegistrationCompletePublisher: reportRegistrationCompleteSubject.eraseToAnyPublisher(),
-            maxPhotoCount: maxPhotoCount)
+            maxPhotoCount: maxPhotoCount,
+            maxContentLength: maxContentLength,
+            maxTitleLength: maxTitleLength)
     }
 
     func action(input: Input) {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 제보하기 QA 대응 (2차)

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- [제보하기 히스토리에서 제목이 1줄만 표시되는 문제](https://www.notion.so/friendshipportfolio/39-301f330eead58043b4d9f074553fb0a2?source=copy_link)
- [제보하기 제목 글자수 제한, 글자 수 표시 (신규 구현)](https://www.notion.so/friendshipportfolio/7-2f0f330eead5801c83fee31371dec644?source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 보고서 등록 시 제목 및 내용의 실시간 글자 수 표시 추가

## 개선 사항
- 제목 텍스트 줄바꿈 지원 확대 (최대 2줄)
- 제목 최대 50자, 내용 최대 150자 입력 제한 적용
- 레이아웃 제약 조건 우선순위 최적화로 유연성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->