### PR TITLE
[Fix] BaseViewController TabBar Hidden 조건 추가

### DIFF
--- a/Projects/Presentation/Sources/Common/Protocol/BaseViewController.swift
+++ b/Projects/Presentation/Sources/Common/Protocol/BaseViewController.swift
@@ -13,8 +13,7 @@ public class BaseViewController<T: ViewModel>: UIViewController {
     let viewModel: T
     private var baseCancellables = Set<AnyCancellable>()
     private lazy var networkErrorView = NetworkErrorView()
-    private var isShowingNetworkError = false
-
+    var isShowingTabBar: Bool { true }
 
     init(viewModel: T) {
         self.viewModel = viewModel
@@ -22,7 +21,7 @@ public class BaseViewController<T: ViewModel>: UIViewController {
     }
 
     deinit {
-        guard isShowingNetworkError else { return }
+        guard isShowingTabBar else { return }
 
         DispatchQueue.main.async { [weak tabBarController = self.tabBarController] in
             tabBarController?.tabBar.isHidden = false
@@ -78,15 +77,15 @@ public class BaseViewController<T: ViewModel>: UIViewController {
 
     /// 네트워크 에러 뷰 를 보이거나 숨깁니다.
     private func handleNetworkErrorView(show: Bool) {
-        isShowingNetworkError = show
-
         if show {
             view.bringSubviewToFront(networkErrorView)
             networkErrorView.isHidden = false
             tabBarController?.tabBar.isHidden = true
         } else {
             networkErrorView.isHidden = true
-            tabBarController?.tabBar.isHidden = false
+            if isShowingTabBar {
+                tabBarController?.tabBar.isHidden = false
+            }
         }
     }
 }

--- a/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
+++ b/Projects/Presentation/Sources/ResultRecommendedRoutine/View/ResultRecommendedRoutineViewController.swift
@@ -80,6 +80,7 @@ final class ResultRecommendedRoutineViewController: BaseViewController<ResultRec
         static let skipButtonBottomSpacing: CGFloat = 20
     }
 
+    override var isShowingTabBar: Bool { false }
     private let mainLabel = UILabel()
     private var subLabel = UILabel()
     private let recommendedRoutineStackView = UIStackView()


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

1. BaseViewController에서 네트워크 오류에 따른 뷰를 보여줄 때 탭바 히든 처리를 진행 
2. 그로 인해 BaseViewController를 상속한 뷰들은 네트워크 수행 후 문제가 없다면 탭바가 보이는게 됨
3. 하지만 온보딩 선택 후 맞춤 추천 루틴을 보여주는 화면에서 2)의 이유로 인해 탭바가 보이게 됨
4. 그렇다고 BaseViewController에 있는 TabBar hidden 로직을 수정하면 네트워크 오류 화면이 사라진 후 탭바 보이는게 제대로 동작하지 않음
5. 이를 해결하기 위해 해당 PR를 작업했어유 ~ 


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- 네트워크 오류 화면


https://github.com/user-attachments/assets/b8c001ad-7285-407e-9a6a-1a353dca081a


- 온보딩 문제 화면 

https://github.com/user-attachments/assets/e9e5fcc4-6a0f-4bd7-8581-3e2547202aee



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- BaseViewController TabBar Hidden 조건 추가


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
#### 1. `isShowingNetworkError` 프로퍼티 삭제

`isShowingNetworkError` 가 아무 역할을 안하는 것 같아가주구 삭제했어요 !!!  
`handleNetworkErrorView` 함수 내부에서도 show로 처리하는 것 같더라구용 ??? 암튼 잘못 삭제했다면 알려주세요 !!!   


#### 2. `isShowingTabBar` 프로퍼티 추가
탭바 hidden 여부를 처리하기 위한 `isShowingTabBar` 프로퍼티를 추가했어유   
근데 상속 받은 View에서 override로 값을 설정해야 해가주구 private으로 못해서 외부 노출 위험이 있습니다 ...    
더 나은 방안이 있다면 말씀해주세요 !!!! 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 권장 루틴 결과 화면에서 탭 바 표시 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->