### PR TITLE
[Fix] 루틴 생성 시 달력 component interaction 수정

### DIFF
--- a/Projects/Presentation/Sources/RoutineCreation/View/Component/BitnagilCalendarView.swift
+++ b/Projects/Presentation/Sources/RoutineCreation/View/Component/BitnagilCalendarView.swift
@@ -47,6 +47,18 @@ final class BitnagilCalendarView: UIViewController {
         configureCalendar()
         configureConfirmButton()
 
+        prevButton.addAction(
+            UIAction{ [weak self] _ in
+                self?.moveMonth(offset: -1)
+            },
+            for: .touchUpInside)
+
+        nextButton.addAction(
+            UIAction{ [weak self] _ in
+                self?.moveMonth(offset: 1)
+            },
+            for: .touchUpInside)
+
         let dateString = Date().convertToString(dateType: .yearMonth)
         dateLabel.text = dateString
         dateLabel.font = BitnagilFont.init(style: .title2, weight: .bold).font
@@ -143,10 +155,27 @@ final class BitnagilCalendarView: UIViewController {
             },
             for: .touchUpInside)
     }
+
+    private func moveMonth(offset: Int) {
+        let currentPage = calendarView.currentPage
+        guard let targetDate = Calendar.current.date(
+            byAdding: .month,
+            value: offset,
+            to: currentPage) else { return }
+        calendarView.setCurrentPage(targetDate, animated: true)
+    }
+
+    private func updateDateLabel(with date: Date) {
+        dateLabel.text = date.convertToString(dateType: .yearMonth)
+    }
 }
 
 extension BitnagilCalendarView: FSCalendarDelegate {
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         delegate?.bitnagilCalendarView(self, didSelectDate: date)
+    }
+
+    func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+        updateDateLabel(with: calendar.currentPage)
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 루틴 등록 QA 대응

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 달력 스와이프 시, 년월에 맞게 Label 의 텍스트가 변경되도록 수정
- 달력 우측 상단의 앞으로가기, 뒤로가기 버튼 활성화


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 달력에서 이전/다음 버튼을 사용한 월간 네비게이션 기능 추가
* 달력 페이지 변경 시 현재 월과 연도 표시 자동 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->